### PR TITLE
Fix HTML entity for single quote

### DIFF
--- a/twitter-text.js
+++ b/twitter-text.js
@@ -11,7 +11,7 @@ if (!window.twttr) {
     '>': '&gt;',
     '<': '&lt;',
     '"': '&quot;',
-    "'": '&#32;'
+    "'": '&#39;'
   };
 
   // HTML escaping


### PR DESCRIPTION
The correct HTML entity for a single apostrophe is `&#39;` [1]

Curious: Are you guys using this library on #NewTwitter?

Cheers,
Daniel

[1] http://stackoverflow.com/questions/419718/html-apostrophe
