### PR TITLE
Extract list mentions with indices

### DIFF
--- a/test/conformance.html
+++ b/test/conformance.html
@@ -51,6 +51,17 @@
                   return res
                 });
               };
+            case "mentions_or_lists_with_indices":
+              return function(test) {
+                var results = twttr.txt.extractMentionsOrListsWithIndices(test.text);
+                return $.map(results, function(res) {
+                  res['screen_name'] = res.screenName;
+                  res['list_slug'] = res.listSlug;
+                  delete res.screenName;
+                  delete res.listSlug;
+                  return res;
+                });
+              };
             case "replies":
               return function(test) {
                 return twttr.txt.extractReplies(test.text);

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -87,6 +87,7 @@ if (!window.twttr) {
   twttr.txt.regexen.extractMentions = regexSupplant(/(^|[^a-zA-Z0-9_])(#{atSigns})([a-zA-Z0-9_]{1,20})(?=(.|$))/g);
   twttr.txt.regexen.extractReply = regexSupplant(/^(?:#{spaces})*#{atSigns}([a-zA-Z0-9_]{1,20})/);
   twttr.txt.regexen.listName = /[a-zA-Z][a-zA-Z0-9_\-\u0080-\u00ff]{0,24}/;
+  twttr.txt.regexen.extractMentionsOrLists = regexSupplant(/(^|[^a-zA-Z0-9_])(#{atSigns})([a-zA-Z0-9_]{1,20})(\/[a-zA-Z][a-zA-Z0-9_\-]{0,24})?(?=(.|$))/g);
 
   var nonLatinHashtagChars = [];
   // Cyrillic
@@ -459,6 +460,35 @@ if (!window.twttr) {
 
     return possibleScreenNames;
   };
+
+  /**
+   * Extract list or user mentions.
+   * (Presence of listSlug indicates a list)
+   */
+  twttr.txt.extractMentionsOrListsWithIndices = function(text) {
+    if (!text) {
+      return [];
+    }
+
+    var possibleNames = [],
+        position = 0;
+
+    text.replace(twttr.txt.regexen.extractMentionsOrLists, function(match, before, atSign, screenName, slashListname, after) {
+      if (!after.match(twttr.txt.regexen.endScreenNameMatch)) {
+        slashListname = slashListname || '';
+        var startPosition = text.indexOf(atSign + screenName + slashListname, position);
+        position = startPosition + screenName.length + slashListname.length + 1;
+        possibleNames.push({
+          screenName: screenName,
+          listSlug: slashListname,
+          indices: [startPosition, position]
+        });
+      }
+    });
+
+    return possibleNames;
+  };
+
 
   twttr.txt.extractReplies = function(text) {
     if (!text) {


### PR DESCRIPTION
Add method for extracting user/list mentions (with indices).

Gets around problem where `extractMentionsWithIndices("one @two/three four")` returns a user mention for 'two' rather than a list (which can mess up linkification).

```
> twttr.txt.extractMentionsOrListsWithIndices("@one @two/three four");
[
  {
    screenName : "one",
    listSlug : "",
    indices : [0, 4]
  },
  {
    screenName : "two",
    listSlug : "/three",
    indices : [5, 15]
  }
]
```
