### PR TITLE
Fix a bug in extractURlsWithIndices to correctly extract URLs without protocol.

### DIFF
--- a/twitter-text.js
+++ b/twitter-text.js
@@ -575,7 +575,7 @@ if (!window.twttr) {
       // if protocol is missing and domain contains non-ASCII characters,
       // extract ASCII-only domains.
       if (!protocol) {
-        var lastUrl,
+        var lastUrl = null,
             lastUrlInvalidMatch = false,
             asciiEndPosition = 0;
         domain.replace(twttr.txt.regexen.validAsciiDomain, function(asciiDomain) {
@@ -591,10 +591,12 @@ if (!window.twttr) {
           }
         });
 
-        if (urls.length == 0) {
+        // no ASCII-only domain found. Skip the entire URL.
+        if (lastUrl == null) {
           return;
         }
 
+        // lastUrl only contains domain. Need to add path and query if they exist.
         if (path) {
           if (lastUrlInvalidMatch) {
             urls.push(lastUrl);


### PR DESCRIPTION
This fixes a bug in twttr.txt.extractUrlsWithIndices() so that it can correctly extract URLs that do not have protocol but have slash '/' after domain (e.g., 't.co/abcde').
