### PR TITLE
Fix hrefs for usernameIncludeSymbol option (issue #30)

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -39,7 +39,7 @@ test("twttr.txt.autolink", function() {
   ok(twttr.txt.autoLink("@tw", { at: "!" }).match(/!<a[^>]+>tw<\/a>/), "Override at");
   ok(twttr.txt.autoLink("@tw", { preChunk: "<b>" }).match(/@<a[^>]+><b>tw<\/a>/), "Override preChunk");
   ok(twttr.txt.autoLink("@tw", { postChunk: "</b>" }).match(/@<a[^>]+>tw<\/b><\/a>/), "Override postChunk");
-  ok(twttr.txt.autoLink("@tw", { usernameIncludeSymbol: true }).match(/<a[^>]+>@tw<\/a>/), "Include @ in the autolink");
+  ok(twttr.txt.autoLink("@tw", { usernameIncludeSymbol: true }).match(/<a[^@>]+>@tw<\/a>/), "Include @ in the autolink");
   ok(!twttr.txt.autoLink("foo http://example.com", { usernameClass: 'custom-user' }).match(/custom-user/), "Override usernameClass should not be applied to URL");
 
   // List Overrides

--- a/test/tests.js
+++ b/test/tests.js
@@ -39,6 +39,7 @@ test("twttr.txt.autolink", function() {
   ok(twttr.txt.autoLink("@tw", { at: "!" }).match(/!<a[^>]+>tw<\/a>/), "Override at");
   ok(twttr.txt.autoLink("@tw", { preChunk: "<b>" }).match(/@<a[^>]+><b>tw<\/a>/), "Override preChunk");
   ok(twttr.txt.autoLink("@tw", { postChunk: "</b>" }).match(/@<a[^>]+>tw<\/b><\/a>/), "Override postChunk");
+  ok(twttr.txt.autoLink("@tw", { usernameIncludeSymbol: true }).match(/<a[^>]+>@tw<\/a>/), "Include @ in the autolink");
   ok(!twttr.txt.autoLink("foo http://example.com", { usernameClass: 'custom-user' }).match(/custom-user/), "Override usernameClass should not be applied to URL");
 
   // List Overrides
@@ -46,6 +47,7 @@ test("twttr.txt.autolink", function() {
   ok(twttr.txt.autoLink("@tw/somelist", { at: "!" }).match(/!<a[^>]+>tw\/somelist<\/a>/), "Override list at");
   ok(twttr.txt.autoLink("@tw/somelist", { preChunk: "<b>" }).match(/@<a[^>]+><b>tw\/somelist<\/a>/), "Override list preChunk");
   ok(twttr.txt.autoLink("@tw/somelist", { postChunk: "</b>" }).match(/@<a[^>]+>tw\/somelist<\/b><\/a>/), "Override list postChunk");
+  ok(twttr.txt.autoLink("@tw/somelist", { usernameIncludeSymbol: true }).match(/<a[^>]+>@tw\/somelist<\/a>/), "Include @ in the autolink");
   ok(twttr.txt.autoLink("foo @tw/somelist", { listClass: 'custom-list' }).match(/custom-list/), "Override listClass");
   ok(!twttr.txt.autoLink("foo @tw/somelist", { usernameClass: 'custom-user' }).match(/custom-user/), "Override usernameClass should not be applied to a List");
 

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -362,13 +362,16 @@ if (!window.twttr) {
             }
           }
           if (options.usernameIncludeSymbol) {
-            d.user = d.at + d.user;
+            d.chunk = d.at + d.user;
             d.at = "";
+          }
+          else {
+            d.chunk = d.user;
           }
 
           if (slashListname && !options.suppressLists) {
             // the link is a list
-            var list = d.chunk = stringSupplant("#{user}#{slashListname}", d);
+            var list = d.chunk = stringSupplant("#{chunk}#{slashListname}", d);
             d.list = twttr.txt.htmlEscape(list.toLowerCase());
             return stringSupplant("#{before}#{at}<a class=\"#{urlClass} #{listClass}\" href=\"#{listUrlBase}#{list}\"#{extraHtml}>#{preChunk}#{chunk}#{postChunk}</a>", d);
           } else {
@@ -377,9 +380,8 @@ if (!window.twttr) {
               return match;
             } else {
               // this is a screen name
-              d.chunk = d.user;
-              d.dataScreenName = !options.suppressDataScreenName ? stringSupplant("data-screen-name=\"#{chunk}\" ", d) : "";
-              return stringSupplant("#{before}#{at}<a class=\"#{urlClass} #{usernameClass}\" #{dataScreenName}href=\"#{usernameUrlBase}#{chunk}\"#{extraHtml}>#{preChunk}#{chunk}#{postChunk}</a>", d);
+              d.dataScreenName = !options.suppressDataScreenName ? stringSupplant("data-screen-name=\"#{user}\" ", d) : "";
+              return stringSupplant("#{before}#{at}<a class=\"#{urlClass} #{usernameClass}\" #{dataScreenName}href=\"#{usernameUrlBase}#{user}\"#{extraHtml}>#{preChunk}#{chunk}#{postChunk}</a>", d);
             }
           }
         });

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -361,6 +361,10 @@ if (!window.twttr) {
               d[k] = options[k];
             }
           }
+          if (options.usernameIncludeSymbol) {
+            d.user = d.at + d.user;
+            d.at = "";
+          }
 
           if (slashListname && !options.suppressLists) {
             // the link is a list
@@ -373,7 +377,7 @@ if (!window.twttr) {
               return match;
             } else {
               // this is a screen name
-              d.chunk = twttr.txt.htmlEscape(user);
+              d.chunk = d.user;
               d.dataScreenName = !options.suppressDataScreenName ? stringSupplant("data-screen-name=\"#{chunk}\" ", d) : "";
               return stringSupplant("#{before}#{at}<a class=\"#{urlClass} #{usernameClass}\" #{dataScreenName}href=\"#{usernameUrlBase}#{chunk}\"#{extraHtml}>#{preChunk}#{chunk}#{postChunk}</a>", d);
             }


### PR DESCRIPTION
This is a fix on top of #30, which was adding the `@` symbol to both the href and the innerText of the link.
