### PR TITLE
Refactor twitter-text to allow punctuation characters before URL.

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -33,6 +33,12 @@ test("twttr.txt.splitTags", function() {
   }
 });
 
+test("twttr.txt.extract", function() {
+  same(twttr.txt.extractHashtagsWithIndices("\uD801\uDC00 #hashtag"), [{hashtag:"hashtag", indices:[2, 10]}], "Hashtag w/ Supplementary character");
+  same(twttr.txt.extractMentionsOrListsWithIndices("\uD801\uDC00 @mention"), [{screenName:"mention", listSlug:"", indices:[2, 10]}], "Mention w/ Supplementary character");
+  same(twttr.txt.extractUrlsWithIndices("\uD801\uDC00 http://twitter.com"), [{url:"http://twitter.com", indices:[2, 20]}], "Hashtag w/ Supplementary character");
+});
+
 test("twttr.txt.autolink", function() {
   // Username Overrides
   ok(twttr.txt.autoLink("@tw", { before: "!" }).match(/!@<a[^>]+>tw<\/a>/), "Override before");
@@ -77,4 +83,8 @@ test("twttr.txt.autolink", function() {
   for (i = 0; i < invalidChars.length; i++) {
     equal(twttr.txt.extractUrls("http://twitt" + invalidChars[i] + "er.com").length, 0, 'Should not extract URL with invalid cahracter');
   }
+
+  same(twttr.txt.autoLink("\uD801\uDC00 #hashtag \uD801\uDC00 @mention \uD801\uDC00 http://twitter.com"),
+      "\uD801\uDC00 <a href=\"http://twitter.com/#!/search?q=%23hashtag\" title=\"#hashtag\" class=\"tweet-url hashtag\" rel=\"nofollow\">#hashtag</a> \uD801\uDC00 @<a class=\"tweet-url username\" data-screen-name=\"mention\" href=\"http://twitter.com/mention\" rel=\"nofollow\">mention</a> \uD801\uDC00 <a href=\"http://twitter.com\" rel=\"nofollow\" >http://twitter.com</a>",
+      "Autolink hashtag/mentionURL w/ Supplementary character");
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -34,9 +34,29 @@ test("twttr.txt.splitTags", function() {
 });
 
 test("twttr.txt.extract", function() {
-  same(twttr.txt.extractHashtagsWithIndices("\uD801\uDC00 #hashtag"), [{hashtag:"hashtag", indices:[2, 10]}], "Hashtag w/ Supplementary character");
-  same(twttr.txt.extractMentionsOrListsWithIndices("\uD801\uDC00 @mention"), [{screenName:"mention", listSlug:"", indices:[2, 10]}], "Mention w/ Supplementary character");
-  same(twttr.txt.extractUrlsWithIndices("\uD801\uDC00 http://twitter.com"), [{url:"http://twitter.com", indices:[2, 20]}], "Hashtag w/ Supplementary character");
+  var text = "\uD801\uDC00 #hashtag \uD801\uDC00 #hashtag";
+  var extracted = twttr.txt.extractHashtagsWithIndices(text);
+  same(extracted, [{hashtag:"hashtag", indices:[3, 11]}, {hashtag:"hashtag", indices:[15, 23]}], "Hashtag w/ Supplementary character, UTF-16 indices");
+  twttr.txt.modifyIndicesFromUTF16ToUnicode(text, extracted);
+  same(extracted, [{hashtag:"hashtag", indices:[2, 10]}, {hashtag:"hashtag", indices:[13, 21]}], "Hashtag w/ Supplementary character, Unicode indices");
+  twttr.txt.modifyIndicesFromUnicodeToUTF16(text, extracted);
+  same(extracted, [{hashtag:"hashtag", indices:[3, 11]}, {hashtag:"hashtag", indices:[15, 23]}], "Hashtag w/ Supplementary character, UTF-16 indices");
+
+  text = "\uD801\uDC00 @mention \uD801\uDC00 @mention";
+  extracted = twttr.txt.extractMentionsOrListsWithIndices(text);
+  same(extracted, [{screenName:"mention", listSlug:"", indices:[3, 11]}, {screenName:"mention", listSlug:"", indices:[15, 23]}], "Mention w/ Supplementary character, UTF-16 indices");
+  twttr.txt.modifyIndicesFromUTF16ToUnicode(text, extracted);
+  same(extracted, [{screenName:"mention", listSlug:"", indices:[2, 10]}, {screenName:"mention", listSlug:"", indices:[13, 21]}], "Mention w/ Supplementary character");
+  twttr.txt.modifyIndicesFromUnicodeToUTF16(text, extracted);
+  same(extracted, [{screenName:"mention", listSlug:"", indices:[3, 11]}, {screenName:"mention", listSlug:"", indices:[15, 23]}], "Mention w/ Supplementary character, UTF-16 indices");
+
+  text = "\uD801\uDC00 http://twitter.com \uD801\uDC00 http://test.com";
+  extracted = twttr.txt.extractUrlsWithIndices(text);
+  same(extracted, [{url:"http://twitter.com", indices:[3, 21]}, {url:"http://test.com", indices:[25, 40]}], "URL w/ Supplementary character, UTF-16 indices");
+  twttr.txt.modifyIndicesFromUTF16ToUnicode(text, extracted);
+  same(extracted, [{url:"http://twitter.com", indices:[2, 20]}, {url:"http://test.com", indices:[23, 38]}], "URL w/ Supplementary character, Unicode indices");
+  twttr.txt.modifyIndicesFromUnicodeToUTF16(text, extracted);
+  same(extracted, [{url:"http://twitter.com", indices:[3, 21]}, {url:"http://test.com", indices:[25, 40]}], "URL w/ Supplementary character, UTF-16 indices");
 });
 
 test("twttr.txt.autolink", function() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -57,6 +57,44 @@ test("twttr.txt.extract", function() {
   same(extracted, [{url:"http://twitter.com", indices:[2, 20]}, {url:"http://test.com", indices:[23, 38]}], "URL w/ Supplementary character, Unicode indices");
   twttr.txt.modifyIndicesFromUnicodeToUTF16(text, extracted);
   same(extracted, [{url:"http://twitter.com", indices:[3, 21]}, {url:"http://test.com", indices:[25, 40]}], "URL w/ Supplementary character, UTF-16 indices");
+
+  var testCases = [
+    {text:"abc", indices:[[0,3]], unicode_indices:[[0,3]]},
+    {text:"\uD83D\uDE02abc", indices:[[2,5]], unicode_indices:[[1,4]]},
+    {text:"\uD83D\uDE02abc\uD83D\uDE02", indices:[[2,5]], unicode_indices:[[1,4]]},
+    {text:"\uD83D\uDE02abc\uD838\uDE02abc", indices:[[2,5], [7,10]], unicode_indices:[[1,4], [5,8]]},
+    {text:"\uD83D\uDE02abc\uD838\uDE02abc\uD83D\uDE02", indices:[[2,5], [7,10]], unicode_indices:[[1,4], [5,8]]},
+    {text:"\uD83D\uDE02\uD83D\uDE02abc", indices:[[4,7]], unicode_indices:[[2,5]]},
+    {text:"\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02abc", indices:[[6,9]], unicode_indices:[[3,6]]},
+    {text:"\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02abc\uD83D\uDE02", indices:[[6,9]], unicode_indices:[[3,6]]},
+    {text:"\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02abc\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02", indices:[[6,9]], unicode_indices:[[3,6]]},
+    {text:"\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02abc\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02abc\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02", indices:[[8,11], [19,22]], unicode_indices:[[4,7], [11,14]]},
+    {text:"\uDE02\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02abc\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02abc\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02", indices:[[7,10], [18,21]], unicode_indices:[[4,7], [11,14]]},
+    {text:"\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02abc\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02abc\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02\uDE02", indices:[[8,11], [19,22]], unicode_indices:[[4,7], [11,14]]},
+    {text:"\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02abc\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02\uD83D\uDE02abc\uD83D\uDE02\uD83D\uDE02\uD83D\uD83D\uDE02\uDE02", indices:[[8,11], [19,22]], unicode_indices:[[4,7], [11,14]]},
+    {text:"\uD83Dabc\uD83D", indices:[[1,4]], unicode_indices:[[1,4]]},
+    {text:"\uDE02abc\uDE02", indices:[[1,4]], unicode_indices:[[1,4]]},
+    {text:"\uDE02\uDE02abc\uDE02\uDE02", indices:[[2,5]], unicode_indices:[[2,5]]},
+    {text:"abcabc", indices:[[0,3], [3,6]], unicode_indices:[[0,3], [3,6]]},
+    {text:"abc\uD83D\uDE02abc", indices:[[0,3], [5,8]], unicode_indices:[[0,3], [4,7]]},
+    {text:"aa", indices:[[0,1], [1,2]], unicode_indices:[[0,1], [1,2]]},
+    {text:"\uD83D\uDE02a\uD83D\uDE02a\uD83D\uDE02", indices:[[2,3], [5,6]], unicode_indices:[[1,2], [3,4]]}
+  ];
+
+  for (var i = 0; i < testCases.length; i++) {
+    entities = [];
+    for (var j = 0; j < testCases[i].indices.length; j++) {
+      entities.push({indices:testCases[i].indices[j]});
+    }
+    twttr.txt.modifyIndicesFromUTF16ToUnicode(testCases[i].text, entities);
+    for (var j = 0; j < testCases[i].indices.length; j++) {
+      same(entities[j].indices, testCases[i].unicode_indices[j], "Convert UTF16 indices to Unicode indices for text '" + testCases[i].text +"'");
+    }
+    twttr.txt.modifyIndicesFromUnicodeToUTF16(testCases[i].text, entities);
+    for (var j = 0; j < testCases[i].indices.length; j++) {
+      same(entities[j].indices, testCases[i].indices[j], "Convert Unicode indices to UTF16 indices for text '" + testCases[i].text +"'");
+    }
+  }
 });
 
 test("twttr.txt.autolink", function() {
@@ -86,7 +124,7 @@ test("twttr.txt.autolink", function() {
   ok(twttr.txt.autoLink("#hi", { postText: "</b>" }).match(/<a[^>]+>#hi<\/b><\/a>/), "Override postText");
 
   // url entities
-  ok(twttr.txt.autoLink("http://t.co/0JG5Mcq", {
+  var autoLinkResult = twttr.txt.autoLink("http://t.co/0JG5Mcq", {
     urlEntities: [{
       "url": "http://t.co/0JG5Mcq",
       "display_url": "blog.twitter.com/2011/05/twitte…",
@@ -96,16 +134,29 @@ test("twttr.txt.autolink", function() {
         103
       ]
     }]
-  }).match(/<a href="http:\/\/t.co\/0JG5Mcq"[^>]+>blog.twitter.com\/2011\/05\/twitte…<\/a>/), 'Use display url from url entities');
+  });
+  ok(autoLinkResult.match(/<a href="http:\/\/t.co\/0JG5Mcq"[^>]+>/), 'Use t.co URL as link target');
+  ok(autoLinkResult.match(/>blog.twitter.com\/2011\/05\/twitte.*…</), 'Use display url from url entities');
+  ok(autoLinkResult.match(/r-for-mac-update.html</), 'Include the tail of expanded_url');
+  ok(autoLinkResult.match(/>http:\/\//), 'Include the head of expanded_url');
+
+  // Insert the HTML into the document and verify that, if copied and pasted, it would get the expanded_url.
+  var div = document.createElement('div');
+  div.innerHTML = autoLinkResult;
+  document.body.appendChild(div);
+  var range = document.createRange();
+  range.selectNode(div);
+  ok(range.toString().match(/\shttp:\/\/blog.twitter.com\/2011\/05\/twitter-for-mac-update.html\s…/), 'Selection copies expanded_url');
+  document.body.removeChild(div);
 
   // urls with invalid character
   var invalidChars = ['\u202A', '\u202B', '\u202C', '\u202D', '\u202E'];
   for (i = 0; i < invalidChars.length; i++) {
-    equal(twttr.txt.extractUrls("http://twitt" + invalidChars[i] + "er.com").length, 0, 'Should not extract URL with invalid cahracter');
+    equal(twttr.txt.extractUrls("http://twitt" + invalidChars[i] + "er.com").length, 0, 'Should not extract URL with invalid character');
   }
 
   same(twttr.txt.autoLink("\uD801\uDC00 #hashtag \uD801\uDC00 @mention \uD801\uDC00 http://twitter.com"),
-      "\uD801\uDC00 <a href=\"http://twitter.com/#!/search?q=%23hashtag\" title=\"#hashtag\" class=\"tweet-url hashtag\" rel=\"nofollow\">#hashtag</a> \uD801\uDC00 @<a class=\"tweet-url username\" data-screen-name=\"mention\" href=\"http://twitter.com/mention\" rel=\"nofollow\">mention</a> \uD801\uDC00 <a href=\"http://twitter.com\" rel=\"nofollow\" >http://twitter.com</a>",
+      "\uD801\uDC00 <a href=\"https://twitter.com/#!/search?q=%23hashtag\" title=\"#hashtag\" class=\"tweet-url hashtag\" rel=\"nofollow\">#hashtag</a> \uD801\uDC00 @<a class=\"tweet-url username\" data-screen-name=\"mention\" href=\"https://twitter.com/mention\" rel=\"nofollow\">mention</a> \uD801\uDC00 <a href=\"http://twitter.com\" rel=\"nofollow\" >http://twitter.com</a>",
       "Autolink hashtag/mentionURL w/ Supplementary character");
 });
 

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -579,16 +579,17 @@ if (!window.twttr) {
     var urls = [],
         position = 0;
 
-    text.replace(twttr.txt.regexen.extractUrl, function(match, all, before, url, protocol, domain, port, path, query) {
-      var startPosition = text.indexOf(url, position),
-          endPosition = startPosition + url.length;
+    while (twttr.txt.regexen.extractUrl.exec(text)) {
+      var before = RegExp.$2, url = RegExp.$3, protocol = RegExp.$4, domain = RegExp.$5, path = RegExp.$7;
+      var endPosition = twttr.txt.regexen.extractUrl.lastIndex,
+          startPosition = endPosition - url.length;
 
       // if protocol is missing and domain contains non-ASCII characters,
       // extract ASCII-only domains.
       if (!protocol) {
         if (!options.extractUrlsWithoutProtocol
             || before.match(twttr.txt.regexen.invalidUrlWithoutProtocolPrecedingChars)) {
-          return;
+          continue;
         }
         var lastUrl = null,
             lastUrlInvalidMatch = false,
@@ -608,7 +609,7 @@ if (!window.twttr) {
 
         // no ASCII-only domain found. Skip the entire URL.
         if (lastUrl == null) {
-          return;
+          continue;
         }
 
         // lastUrl only contains domain. Need to add path and query if they exist.
@@ -630,7 +631,7 @@ if (!window.twttr) {
           indices: [startPosition, endPosition]
         });
       }
-    });
+    }
 
     return urls;
   };

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -132,11 +132,12 @@ if (!window.twttr) {
   twttr.txt.regexen.latinAccentChars = regexSupplant("ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþş\\303\\277");
 
   // A hashtag must contain characters, numbers and underscores, but not all numbers.
+  twttr.txt.regexen.hashSigns = /[#＃]/;
   twttr.txt.regexen.hashtagAlpha = regexSupplant(/[a-z_#{latinAccentChars}#{nonLatinHashtagChars}]/i);
   twttr.txt.regexen.hashtagAlphaNumeric = regexSupplant(/[a-z0-9_#{latinAccentChars}#{nonLatinHashtagChars}]/i);
-  twttr.txt.regexen.endHashtagMatch = /^(?:[#＃]|:\/\/)/;
+  twttr.txt.regexen.endHashtagMatch = regexSupplant(/^(?:#{hashSigns}|:\/\/)/);
   twttr.txt.regexen.hashtagBoundary = regexSupplant(/(?:^|$|[^&\/a-z0-9_#{latinAccentChars}#{nonLatinHashtagChars}])/);
-  twttr.txt.regexen.validHashtag = regexSupplant(/(#{hashtagBoundary})(#|＃)(#{hashtagAlphaNumeric}*#{hashtagAlpha}#{hashtagAlphaNumeric}*)/gi);
+  twttr.txt.regexen.validHashtag = regexSupplant(/(#{hashtagBoundary})(#{hashSigns})(#{hashtagAlphaNumeric}*#{hashtagAlpha}#{hashtagAlphaNumeric}*)/gi);
 
   // Mention related regex collection
   twttr.txt.regexen.validMentionPrecedingChars = /(?:^|[^a-zA-Z0-9_]|RT:?)/;
@@ -147,7 +148,6 @@ if (!window.twttr) {
     '([a-zA-Z0-9_]{1,20})' +             // $3: Screen name
     '(\/[a-zA-Z][a-zA-Z0-9_\-]{0,24})?'  // $4: List (optional)
   , 'g');
-    /(^|[^a-zA-Z0-9_]|RT:?)([@＠])([a-zA-Z0-9_]{1,20})(\/[a-zA-Z][a-zA-Z0-9_\-]{0,24})?/g;
   twttr.txt.regexen.validReply = regexSupplant(/^(?:#{spaces})*#{atSigns}([a-zA-Z0-9_]{1,20})/);
   twttr.txt.regexen.endMentionMatch = regexSupplant(/^(?:#{atSigns}|[#{latinAccentChars}]|:\/\/)/);
 
@@ -517,7 +517,7 @@ if (!window.twttr) {
    * (Presence of listSlug indicates a list)
    */
   twttr.txt.extractMentionsOrListsWithIndices = function(text) {
-    if (!text || !text.match(/[@＠]/)) {
+    if (!text || !text.match(twttr.txt.regexen.atSign)) {
       return [];
     }
 
@@ -647,7 +647,7 @@ if (!window.twttr) {
   };
 
   twttr.txt.extractHashtagsWithIndices = function(text) {
-    if (!text || !text.match(/[#＃]/)) {
+    if (!text || !text.match(twttr.txt.regexen.hashSigns)) {
       return [];
     }
 

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -198,30 +198,6 @@ if (typeof twttr === "undefined" || twttr === null) {
   addCharsToCharClass(latinAccentChars, 0x1e00, 0x1eff);
   twttr.txt.regexen.latinAccentChars = regexSupplant(latinAccentChars.join(""));
 
-  var latinAccentChars = [];
-  // Latin accented characters (subtracted 0xD7 from the range, it's a confusable multiplication sign. Looks like "x")
-  addCharsToCharClass(latinAccentChars, 0x00c0, 0x00d6);
-  addCharsToCharClass(latinAccentChars, 0x00d8, 0x00f6);
-  addCharsToCharClass(latinAccentChars, 0x00f8, 0x00ff);
-  // Latin Extended A and B
-  addCharsToCharClass(latinAccentChars, 0x0100, 0x024f);
-  // assorted IPA Extensions
-  addCharsToCharClass(latinAccentChars, 0x0253, 0x0254);
-  addCharsToCharClass(latinAccentChars, 0x0256, 0x0257);
-  addCharsToCharClass(latinAccentChars, 0x0259, 0x0259);
-  addCharsToCharClass(latinAccentChars, 0x025b, 0x025b);
-  addCharsToCharClass(latinAccentChars, 0x0263, 0x0263);
-  addCharsToCharClass(latinAccentChars, 0x0268, 0x0268);
-  addCharsToCharClass(latinAccentChars, 0x026f, 0x026f);
-  addCharsToCharClass(latinAccentChars, 0x0272, 0x0272);
-  addCharsToCharClass(latinAccentChars, 0x0289, 0x0289);
-  addCharsToCharClass(latinAccentChars, 0x028b, 0x028b);
-  // Okina for Hawaiian (it *is* a letter character)
-  addCharsToCharClass(latinAccentChars, 0x02bb, 0x02bb);
-  // Latin Extended Additional
-  addCharsToCharClass(latinAccentChars, 0x1e00, 0x1eff);
-  twttr.txt.regexen.latinAccentChars = regexSupplant(latinAccentChars.join(""));
-
   // A hashtag must contain characters, numbers and underscores, but not all numbers.
   twttr.txt.regexen.hashSigns = /[#＃]/;
   twttr.txt.regexen.hashtagAlpha = regexSupplant(/[a-z_#{latinAccentChars}#{nonLatinHashtagChars}]/i);
@@ -279,7 +255,7 @@ if (typeof twttr === "undefined" || twttr === null) {
   twttr.txt.regexen.validUrlQueryEndingChars = /[a-z0-9_&=#\/]/i;
   twttr.txt.regexen.extractUrl = regexSupplant(
     '('                                                            + // $1 total match
-      '(#{validUrlPrecedingChars})'                                   + // $2 Preceeding chracter
+      '(#{validUrlPrecedingChars})'                                + // $2 Preceeding chracter
       '('                                                          + // $3 URL
         '(https?:\\/\\/)?'                                         + // $4 Protocol (optional)
         '(#{validDomain})'                                         + // $5 Domain(s)
@@ -503,7 +479,7 @@ if (typeof twttr === "undefined" || twttr === null) {
           afterDisplayUrl: expandedUrl.substr(displayUrlIndex + displayUrlSansEllipses.length),
           precedingEllipsis: displayUrl.match(/^…/) ? "…" : "",
           followingEllipsis: displayUrl.match(/…$/) ? "…" : ""
-        }
+        };
         $.each(v, function(index, value) {
           v[index] = twttr.txt.htmlEscape(value);
         });
@@ -924,7 +900,6 @@ if (typeof twttr === "undefined" || twttr === null) {
     var tagName = options.tag || defaultHighlightTag,
         tags = ["<" + tagName + ">", "</" + tagName + ">"],
         chunks = twttr.txt.splitTags(text),
-        split,
         i,
         j,
         result = "",

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -531,13 +531,12 @@ if (typeof twttr === "undefined" || twttr === null) {
     options.urlClass = options.urlClass || DEFAULT_URL_CLASS;
     options.hashtagClass = options.hashtagClass || DEFAULT_HASHTAG_CLASS;
     options.hashtagUrlBase = options.hashtagUrlBase || "https://twitter.com/#!/search?q=%23";
-    options.urlClass = options.urlClass || DEFAULT_URL_CLASS;
     options.listClass = options.listClass || DEFAULT_LIST_CLASS;
     options.usernameClass = options.usernameClass || DEFAULT_USERNAME_CLASS;
     options.usernameUrlBase = options.usernameUrlBase || "https://twitter.com/";
     options.listUrlBase = options.listUrlBase || "https://twitter.com/";
     options.before = options.before || "";
-    options.htmlAttrs = twttr.txt.htmlAttrForOptions(options);
+    options.htmlAttrs = twttr.txt.extractHtmlAttrsFromOptions(options);
 
     // remap url entities to hash
     var urlEntities, i, len;
@@ -569,7 +568,7 @@ if (typeof twttr === "undefined" || twttr === null) {
     return result;
   };
 
-  twttr.txt.htmlAttrForOptions = function(options) {
+  twttr.txt.extractHtmlAttrsFromOptions = function(options) {
     var htmlAttrs = "";
     for (var k in options) {
       var v = options[k];

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -440,7 +440,7 @@ if (!window.twttr) {
   };
 
   twttr.txt.autoLink = function(text, options) {
-    var entities = twttr.txt.extractEntitiesWithIndices(text, {extractUrlWithoutProtocol: false, countSupplementaryCharacterAsOne: false});
+    var entities = twttr.txt.extractEntitiesWithIndices(text, {extractUrlWithoutProtocol: false});
     return twttr.txt.autoLinkEntities(text, entities, options);
   };
 
@@ -461,8 +461,8 @@ if (!window.twttr) {
 
   twttr.txt.extractEntitiesWithIndices = function(text, options) {
     var entities = twttr.txt.extractUrlsWithIndices(text, options)
-                   .concat(twttr.txt.extractMentionsOrListsWithIndices(text, options))
-                   .concat(twttr.txt.extractHashtagsWithIndices(text, options));
+                   .concat(twttr.txt.extractMentionsOrListsWithIndices(text))
+                   .concat(twttr.txt.extractHashtagsWithIndices(text));
 
     if (entities.length == 0) {
       return [];
@@ -495,11 +495,7 @@ if (!window.twttr) {
     return screenNamesOnly;
   };
 
-  twttr.txt.extractMentionsWithIndices = function(text, options) {
-    if (!options) {
-      options = {countSupplementaryCharacterAsOne: true};
-    }
-
+  twttr.txt.extractMentionsWithIndices = function(text) {
     var mentions = [];
     var mentionsOrLists = twttr.txt.extractMentionsOrListsWithIndices(text);
 
@@ -513,9 +509,6 @@ if (!window.twttr) {
       }
     }
 
-    if (options.countSupplementaryCharacterAsOne) {
-      twttr.txt.adjustIndices(text, mentions, -1);
-    }
     return mentions;
   };
 
@@ -523,13 +516,9 @@ if (!window.twttr) {
    * Extract list or user mentions.
    * (Presence of listSlug indicates a list)
    */
-  twttr.txt.extractMentionsOrListsWithIndices = function(text, options) {
+  twttr.txt.extractMentionsOrListsWithIndices = function(text) {
     if (!text || !text.match(twttr.txt.regexen.atSign)) {
       return [];
-    }
-
-    if (!options) {
-      options = {countSupplementaryCharacterAsOne: true};
     }
 
     var possibleNames = [],
@@ -549,9 +538,6 @@ if (!window.twttr) {
       }
     });
 
-    if (options.countSupplementaryCharacterAsOne) {
-      twttr.txt.adjustIndices(text, possibleNames, -1);
-    }
     return possibleNames;
   };
 
@@ -583,7 +569,7 @@ if (!window.twttr) {
 
   twttr.txt.extractUrlsWithIndices = function(text, options) {
     if (!options) {
-      options = {extractUrlsWithoutProtocol: true, countSupplementaryCharacterAsOne: true};
+      options = {extractUrlsWithoutProtocol: true};
     }
 
     if (!text || (options.extractUrlsWithoutProtocol ? !text.match(/\./) : !text.match(/:/))) {
@@ -646,10 +632,6 @@ if (!window.twttr) {
       }
     });
 
-    if (options.countSupplementaryCharacterAsOne) {
-      twttr.txt.adjustIndices(text, urls, -1);
-    }
-
     return urls;
   };
 
@@ -664,13 +646,9 @@ if (!window.twttr) {
     return hashtagsOnly;
   };
 
-  twttr.txt.extractHashtagsWithIndices = function(text, options) {
+  twttr.txt.extractHashtagsWithIndices = function(text) {
     if (!text || !text.match(twttr.txt.regexen.hashSigns)) {
       return [];
-    }
-
-    if (!options) {
-      options = {countSupplementaryCharacterAsOne: true};
     }
 
     var tags = [],
@@ -688,14 +666,18 @@ if (!window.twttr) {
       });
     });
 
-    if (options.countSupplementaryCharacterAsOne) {
-      twttr.txt.adjustIndices(text, tags, -1);
-    }
-
     return tags;
   };
 
-  twttr.txt.adjustIndices = function(text, entities, diff) {
+  twttr.txt.modifyIndicesFromUnicodeToUTF16 = function(text, entities) {
+    twttr.txt.shiftIndices(text, entities, 1);
+  };
+
+  twttr.txt.modifyIndicesFromUTF16ToUnicode = function(text, entities) {
+    twttr.txt.shiftIndices(text, entities, -1);
+  };
+
+  twttr.txt.shiftIndices = function(text, entities, diff) {
     for (var i = 0; i < text.length - 1; i++) {
       var c1 = text.charCodeAt(i);
       var c2 = text.charCodeAt(i + 1);
@@ -709,7 +691,7 @@ if (!window.twttr) {
         }
       }
     }
-  }
+  };
 
   // this essentially does text.split(/<|>/)
   // except that won't work in IE, where empty strings are ommitted

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -152,7 +152,8 @@ if (!window.twttr) {
   twttr.txt.regexen.endMentionMatch = regexSupplant(/^(?:#{atSigns}|[#{latinAccentChars}]|:\/\/)/);
 
   // URL related regex collection
-  twttr.txt.regexen.validUrlPrecedingChars = regexSupplant(/(?:[^-\/"'!=A-Za-z0-9_@＠$#＃\.#{invalid_chars_group}]|^)/);
+  twttr.txt.regexen.validUrlPrecedingChars = regexSupplant(/(?:[^A-Za-z0-9@＠$#＃#{invalid_chars_group}]|^)/);
+  twttr.txt.regexen.invalidUrlWithoutProtocolPrecedingChars = /[-_.\/]$/;
   twttr.txt.regexen.invalidDomainChars = stringSupplant("#{punct}#{spaces_group}#{invalid_chars_group}", twttr.txt.regexen);
   twttr.txt.regexen.validDomainChars = regexSupplant(/[^#{invalidDomainChars}]/);
   twttr.txt.regexen.validSubdomain = regexSupplant(/(?:(?:#{validDomainChars}(?:[_-]|#{validDomainChars})*)?#{validDomainChars}\.)/);
@@ -585,7 +586,8 @@ if (!window.twttr) {
       // if protocol is missing and domain contains non-ASCII characters,
       // extract ASCII-only domains.
       if (!protocol) {
-        if (!options.extractUrlsWithoutProtocol) {
+        if (!options.extractUrlsWithoutProtocol
+            || before.match(twttr.txt.regexen.invalidUrlWithoutProtocolPrecedingChars)) {
           return;
         }
         var lastUrl = null,

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -440,7 +440,7 @@ if (!window.twttr) {
   };
 
   twttr.txt.autoLink = function(text, options) {
-    var entities = twttr.txt.extractEntitiesWithIndices(text, {extractUrlWithoutProtocol: false});
+    var entities = twttr.txt.extractEntitiesWithIndices(text, {extractUrlWithoutProtocol: false, countSupplementaryCharacterAsOne: false});
     return twttr.txt.autoLinkEntities(text, entities, options);
   };
 
@@ -461,8 +461,8 @@ if (!window.twttr) {
 
   twttr.txt.extractEntitiesWithIndices = function(text, options) {
     var entities = twttr.txt.extractUrlsWithIndices(text, options)
-                   .concat(twttr.txt.extractMentionsOrListsWithIndices(text))
-                   .concat(twttr.txt.extractHashtagsWithIndices(text));
+                   .concat(twttr.txt.extractMentionsOrListsWithIndices(text, options))
+                   .concat(twttr.txt.extractHashtagsWithIndices(text, options));
 
     if (entities.length == 0) {
       return [];
@@ -495,7 +495,11 @@ if (!window.twttr) {
     return screenNamesOnly;
   };
 
-  twttr.txt.extractMentionsWithIndices = function(text) {
+  twttr.txt.extractMentionsWithIndices = function(text, options) {
+    if (!options) {
+      options = {countSupplementaryCharacterAsOne: true};
+    }
+
     var mentions = [];
     var mentionsOrLists = twttr.txt.extractMentionsOrListsWithIndices(text);
 
@@ -509,6 +513,9 @@ if (!window.twttr) {
       }
     }
 
+    if (options.countSupplementaryCharacterAsOne) {
+      twttr.txt.adjustIndices(text, mentions, -1);
+    }
     return mentions;
   };
 
@@ -516,9 +523,13 @@ if (!window.twttr) {
    * Extract list or user mentions.
    * (Presence of listSlug indicates a list)
    */
-  twttr.txt.extractMentionsOrListsWithIndices = function(text) {
+  twttr.txt.extractMentionsOrListsWithIndices = function(text, options) {
     if (!text || !text.match(twttr.txt.regexen.atSign)) {
       return [];
+    }
+
+    if (!options) {
+      options = {countSupplementaryCharacterAsOne: true};
     }
 
     var possibleNames = [],
@@ -538,6 +549,9 @@ if (!window.twttr) {
       }
     });
 
+    if (options.countSupplementaryCharacterAsOne) {
+      twttr.txt.adjustIndices(text, possibleNames, -1);
+    }
     return possibleNames;
   };
 
@@ -569,7 +583,7 @@ if (!window.twttr) {
 
   twttr.txt.extractUrlsWithIndices = function(text, options) {
     if (!options) {
-      options = {extractUrlsWithoutProtocol: true};
+      options = {extractUrlsWithoutProtocol: true, countSupplementaryCharacterAsOne: true};
     }
 
     if (!text || (options.extractUrlsWithoutProtocol ? !text.match(/\./) : !text.match(/:/))) {
@@ -632,6 +646,10 @@ if (!window.twttr) {
       }
     });
 
+    if (options.countSupplementaryCharacterAsOne) {
+      twttr.txt.adjustIndices(text, urls, -1);
+    }
+
     return urls;
   };
 
@@ -646,9 +664,13 @@ if (!window.twttr) {
     return hashtagsOnly;
   };
 
-  twttr.txt.extractHashtagsWithIndices = function(text) {
+  twttr.txt.extractHashtagsWithIndices = function(text, options) {
     if (!text || !text.match(twttr.txt.regexen.hashSigns)) {
       return [];
+    }
+
+    if (!options) {
+      options = {countSupplementaryCharacterAsOne: true};
     }
 
     var tags = [],
@@ -666,8 +688,28 @@ if (!window.twttr) {
       });
     });
 
+    if (options.countSupplementaryCharacterAsOne) {
+      twttr.txt.adjustIndices(text, tags, -1);
+    }
+
     return tags;
   };
+
+  twttr.txt.adjustIndices = function(text, entities, diff) {
+    for (var i = 0; i < text.length - 1; i++) {
+      var c1 = text.charCodeAt(i);
+      var c2 = text.charCodeAt(i + 1);
+      if (0xD800 <= c1 && c1 <= 0xDBFF && 0xDC00 <= c2 && c2 <= 0xDFFF) {
+        // supplementary character
+        for (var j = 0; j < entities.length; j++) {
+          if (entities[j].indices[0] >= i) {
+            entities[j].indices[0] += diff;
+            entities[j].indices[1] += diff;
+          }
+        }
+      }
+    }
+  }
 
   // this essentially does text.split(/<|>/)
   // except that won't work in IE, where empty strings are ommitted

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -517,7 +517,7 @@ if (!window.twttr) {
    * (Presence of listSlug indicates a list)
    */
   twttr.txt.extractMentionsOrListsWithIndices = function(text) {
-    if (!text) {
+    if (!text || !text.match(/[@＠]/)) {
       return [];
     }
 
@@ -568,16 +568,16 @@ if (!window.twttr) {
   };
 
   twttr.txt.extractUrlsWithIndices = function(text, options) {
-    if (!text) {
+    if (!options) {
+      options = {extractUrlsWithoutProtocol: true};
+    }
+
+    if (!text || (options.extractUrlsWithoutProtocol ? !text.match(/\./) : !text.match(/:/))) {
       return [];
     }
 
     var urls = [],
         position = 0;
-
-    if (!options) {
-      options = {extractUrlsWithoutProtocol: true};
-    }
 
     text.replace(twttr.txt.regexen.extractUrl, function(match, all, before, url, protocol, domain, port, path, query) {
       var startPosition = text.indexOf(url, position),
@@ -647,7 +647,7 @@ if (!window.twttr) {
   };
 
   twttr.txt.extractHashtagsWithIndices = function(text) {
-    if (!text) {
+    if (!text || !text.match(/[#＃]/)) {
       return [];
     }
 


### PR DESCRIPTION
Currently twitter-text doesn't allow punctuation characters like " or . before URL. But if we change Regex to allow those characters before URL autoLink() will break because it'll auto-link the URLs added by autoLinkHashtags/UsernamesAndLists(). To solve it, this modifies autoLink() to use extractEntitiesWithIndices() to extract all entities first, then use them to auto-link the text.

This also includes performance improvement (which doubles the speed of Autolink/Extractor on my laptop) as well as other minor refactoring.

Here is the list of changes in this branch:
- Add new method extractEntitiesWithIndices(), which extracts all entities (hashtag, mention, URLs) from a given text.
- Modify autoLink_() to use extract_() to extract entities instead of applying Regex.
- Allow punctuation characters like '"', '.' or '!' before URL.
- Consolidate AUTO_LINK_USERNAMES\* and EXTRACT_MENTIONS into VALID_MENTION_OR_LIST
- Improve performance of extract*() by scanning the text before applying complex regex patterns.
- Add an option in extractUrls*() to enable/disable extracting URLs without protocol.
