### PR TITLE
Extract mentions slightly more strictly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "twitter-text"
   , "description": "official twitter text linkification"
-  , "version": "1.4.14"
+  , "version": "1.4.15"
   , "main": "./twitter-text.js"
   , "homepage": "https://github.com/twitter/twitter-text-js"
   , "author": "Twitter Inc."

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "twitter-text"
   , "description": "official twitter text linkification"
-  , "version": "1.4.15"
+  , "version": "1.4.14"
   , "main": "./twitter-text.js"
   , "homepage": "https://github.com/twitter/twitter-text-js"
   , "author": "Twitter Inc."

--- a/test/tests.js
+++ b/test/tests.js
@@ -79,7 +79,6 @@ test("twttr.txt.autolink", function() {
   }
 });
 
-
 test("twttr.txt.extractMentionsOrListsWithIndices", function() {
   var invalid_chars = ['!', '@', '#', '$', '%', '&', '*']
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -78,3 +78,13 @@ test("twttr.txt.autolink", function() {
     equal(twttr.txt.extractUrls("http://twitt" + invalidChars[i] + "er.com").length, 0, 'Should not extract URL with invalid cahracter');
   }
 });
+
+
+test("twttr.txt.extractMentionsOrListsWithIndices", function() {
+  var invalid_chars = ['!', '@', '#', '$', '%', '&', '*']
+
+  for (var i = 0; i < invalid_chars.length; i++) {
+    c = invalid_chars[i];
+    equal(twttr.txt.extractMentionsOrListsWithIndices("f" + c + "@kn").length, 0, "Should not extract mention if precedented by " + c);
+  }
+});

--- a/test/tests.js
+++ b/test/tests.js
@@ -85,6 +85,6 @@ test("twttr.txt.extractMentionsOrListsWithIndices", function() {
 
   for (var i = 0; i < invalid_chars.length; i++) {
     c = invalid_chars[i];
-    equal(twttr.txt.extractMentionsOrListsWithIndices("f" + c + "@kn").length, 0, "Should not extract mention if precedented by " + c);
+    equal(twttr.txt.extractMentionsOrListsWithIndices("f" + c + "@kn").length, 0, "Should not extract mention if preceded by " + c);
   }
 });

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -97,7 +97,7 @@ if (!window.twttr) {
   twttr.txt.regexen.extractMentions = regexSupplant(/(^|[^a-zA-Z0-9_])(#{atSigns})([a-zA-Z0-9_]{1,20})/g);
   twttr.txt.regexen.extractReply = regexSupplant(/^(?:#{spaces})*#{atSigns}([a-zA-Z0-9_]{1,20})/);
   twttr.txt.regexen.listName = /[a-zA-Z][a-zA-Z0-9_\-\u0080-\u00ff]{0,24}/;
-  twttr.txt.regexen.extractMentionsOrLists = regexSupplant(/(^|[^a-zA-Z0-9_])(#{atSigns})([a-zA-Z0-9_]{1,20})(\/[a-zA-Z][a-zA-Z0-9_\-]{0,24})?/g);
+  twttr.txt.regexen.extractMentionsOrLists = regexSupplant(/(^|[^a-zA-Z0-9_!#$%&*@＠])(#{atSigns})([a-zA-Z0-9_]{1,20})(\/[a-zA-Z][a-zA-Z0-9_\-]{0,24})?/g);
 
   var nonLatinHashtagChars = [];
   // Cyrillic


### PR DESCRIPTION
I made extraction of mentions slightly more strict.
Now it does not extract mentions precedented by !, @, #, $, %, & and .
This avoids extracting unintended mentions like "f@KN", which, in turn, reduces spams in users mention section.
