### PR TITLE
Add twttr.txt.modifyIndices{FromUTF16ToUnicode(), FromUnicodeToUTF16()}

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -33,6 +33,12 @@ test("twttr.txt.splitTags", function() {
   }
 });
 
+test("twttr.txt.extract", function() {
+  same(twttr.txt.extractHashtagsWithIndices("\uD801\uDC00 #hashtag"), [{hashtag:"hashtag", indices:[2, 10]}], "Hashtag w/ Supplementary character");
+  same(twttr.txt.extractMentionsOrListsWithIndices("\uD801\uDC00 @mention"), [{screenName:"mention", listSlug:"", indices:[2, 10]}], "Mention w/ Supplementary character");
+  same(twttr.txt.extractUrlsWithIndices("\uD801\uDC00 http://twitter.com"), [{url:"http://twitter.com", indices:[2, 20]}], "Hashtag w/ Supplementary character");
+});
+
 test("twttr.txt.autolink", function() {
   // Username Overrides
   ok(twttr.txt.autoLink("@tw", { before: "!" }).match(/!@<a[^>]+>tw<\/a>/), "Override before");
@@ -77,4 +83,8 @@ test("twttr.txt.autolink", function() {
   for (i = 0; i < invalidChars.length; i++) {
     equal(twttr.txt.extractUrls("http://twitt" + invalidChars[i] + "er.com").length, 0, 'Should not extract URL with invalid cahracter');
   }
+
+  same(twttr.txt.autoLink("\uD801\uDC00 #hashtag \uD801\uDC00 @mention \uD801\uDC00 http://twitter.com"),
+      "\uD801\uDC00 <a href=\"http://twitter.com/#!/search?q=%23hashtag\" title=\"#hashtag\" class=\"tweet-url hashtag\" rel=\"nofollow\">#hashtag</a> \uD801\uDC00 @<a class=\"tweet-url username\" data-screen-name=\"mention\" href=\"http://twitter.com/mention\" rel=\"nofollow\">mention</a> \uD801\uDC00 <a href=\"http://twitter.com\" rel=\"nofollow\" >http://twitter.com</a>",
+      "Autolink hashtag/mentionURL w/ Supplementary character");
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -34,9 +34,29 @@ test("twttr.txt.splitTags", function() {
 });
 
 test("twttr.txt.extract", function() {
-  same(twttr.txt.extractHashtagsWithIndices("\uD801\uDC00 #hashtag"), [{hashtag:"hashtag", indices:[2, 10]}], "Hashtag w/ Supplementary character");
-  same(twttr.txt.extractMentionsOrListsWithIndices("\uD801\uDC00 @mention"), [{screenName:"mention", listSlug:"", indices:[2, 10]}], "Mention w/ Supplementary character");
-  same(twttr.txt.extractUrlsWithIndices("\uD801\uDC00 http://twitter.com"), [{url:"http://twitter.com", indices:[2, 20]}], "Hashtag w/ Supplementary character");
+  var text = "\uD801\uDC00 #hashtag \uD801\uDC00 #hashtag";
+  var extracted = twttr.txt.extractHashtagsWithIndices(text);
+  same(extracted, [{hashtag:"hashtag", indices:[3, 11]}, {hashtag:"hashtag", indices:[15, 23]}], "Hashtag w/ Supplementary character, UTF-16 indices");
+  twttr.txt.modifyIndicesFromUTF16ToUnicode(text, extracted);
+  same(extracted, [{hashtag:"hashtag", indices:[2, 10]}, {hashtag:"hashtag", indices:[13, 21]}], "Hashtag w/ Supplementary character, Unicode indices");
+  twttr.txt.modifyIndicesFromUnicodeToUTF16(text, extracted);
+  same(extracted, [{hashtag:"hashtag", indices:[3, 11]}, {hashtag:"hashtag", indices:[15, 23]}], "Hashtag w/ Supplementary character, UTF-16 indices");
+
+  text = "\uD801\uDC00 @mention \uD801\uDC00 @mention";
+  extracted = twttr.txt.extractMentionsOrListsWithIndices(text);
+  same(extracted, [{screenName:"mention", listSlug:"", indices:[3, 11]}, {screenName:"mention", listSlug:"", indices:[15, 23]}], "Mention w/ Supplementary character, UTF-16 indices");
+  twttr.txt.modifyIndicesFromUTF16ToUnicode(text, extracted);
+  same(extracted, [{screenName:"mention", listSlug:"", indices:[2, 10]}, {screenName:"mention", listSlug:"", indices:[13, 21]}], "Mention w/ Supplementary character");
+  twttr.txt.modifyIndicesFromUnicodeToUTF16(text, extracted);
+  same(extracted, [{screenName:"mention", listSlug:"", indices:[3, 11]}, {screenName:"mention", listSlug:"", indices:[15, 23]}], "Mention w/ Supplementary character, UTF-16 indices");
+
+  text = "\uD801\uDC00 http://twitter.com \uD801\uDC00 http://test.com";
+  extracted = twttr.txt.extractUrlsWithIndices(text);
+  same(extracted, [{url:"http://twitter.com", indices:[3, 21]}, {url:"http://test.com", indices:[25, 40]}], "URL w/ Supplementary character, UTF-16 indices");
+  twttr.txt.modifyIndicesFromUTF16ToUnicode(text, extracted);
+  same(extracted, [{url:"http://twitter.com", indices:[2, 20]}, {url:"http://test.com", indices:[23, 38]}], "URL w/ Supplementary character, Unicode indices");
+  twttr.txt.modifyIndicesFromUnicodeToUTF16(text, extracted);
+  same(extracted, [{url:"http://twitter.com", indices:[3, 21]}, {url:"http://test.com", indices:[25, 40]}], "URL w/ Supplementary character, UTF-16 indices");
 });
 
 test("twttr.txt.autolink", function() {

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -440,7 +440,7 @@ if (!window.twttr) {
   };
 
   twttr.txt.autoLink = function(text, options) {
-    var entities = twttr.txt.extractEntitiesWithIndices(text, {extractUrlWithoutProtocol: false, countSupplementaryCharacterAsOne: false});
+    var entities = twttr.txt.extractEntitiesWithIndices(text, {extractUrlWithoutProtocol: false});
     return twttr.txt.autoLinkEntities(text, entities, options);
   };
 
@@ -461,8 +461,8 @@ if (!window.twttr) {
 
   twttr.txt.extractEntitiesWithIndices = function(text, options) {
     var entities = twttr.txt.extractUrlsWithIndices(text, options)
-                   .concat(twttr.txt.extractMentionsOrListsWithIndices(text, options))
-                   .concat(twttr.txt.extractHashtagsWithIndices(text, options));
+                   .concat(twttr.txt.extractMentionsOrListsWithIndices(text))
+                   .concat(twttr.txt.extractHashtagsWithIndices(text));
 
     if (entities.length == 0) {
       return [];
@@ -495,11 +495,7 @@ if (!window.twttr) {
     return screenNamesOnly;
   };
 
-  twttr.txt.extractMentionsWithIndices = function(text, options) {
-    if (!options) {
-      options = {countSupplementaryCharacterAsOne: true};
-    }
-
+  twttr.txt.extractMentionsWithIndices = function(text) {
     var mentions = [];
     var mentionsOrLists = twttr.txt.extractMentionsOrListsWithIndices(text);
 
@@ -513,9 +509,6 @@ if (!window.twttr) {
       }
     }
 
-    if (options.countSupplementaryCharacterAsOne) {
-      twttr.txt.adjustIndices(text, mentions, -1);
-    }
     return mentions;
   };
 
@@ -523,13 +516,9 @@ if (!window.twttr) {
    * Extract list or user mentions.
    * (Presence of listSlug indicates a list)
    */
-  twttr.txt.extractMentionsOrListsWithIndices = function(text, options) {
+  twttr.txt.extractMentionsOrListsWithIndices = function(text) {
     if (!text || !text.match(twttr.txt.regexen.atSign)) {
       return [];
-    }
-
-    if (!options) {
-      options = {countSupplementaryCharacterAsOne: true};
     }
 
     var possibleNames = [],
@@ -549,9 +538,6 @@ if (!window.twttr) {
       }
     });
 
-    if (options.countSupplementaryCharacterAsOne) {
-      twttr.txt.adjustIndices(text, possibleNames, -1);
-    }
     return possibleNames;
   };
 
@@ -583,7 +569,7 @@ if (!window.twttr) {
 
   twttr.txt.extractUrlsWithIndices = function(text, options) {
     if (!options) {
-      options = {extractUrlsWithoutProtocol: true, countSupplementaryCharacterAsOne: true};
+      options = {extractUrlsWithoutProtocol: true};
     }
 
     if (!text || (options.extractUrlsWithoutProtocol ? !text.match(/\./) : !text.match(/:/))) {
@@ -646,10 +632,6 @@ if (!window.twttr) {
       }
     });
 
-    if (options.countSupplementaryCharacterAsOne) {
-      twttr.txt.adjustIndices(text, urls, -1);
-    }
-
     return urls;
   };
 
@@ -664,13 +646,9 @@ if (!window.twttr) {
     return hashtagsOnly;
   };
 
-  twttr.txt.extractHashtagsWithIndices = function(text, options) {
+  twttr.txt.extractHashtagsWithIndices = function(text) {
     if (!text || !text.match(twttr.txt.regexen.hashSigns)) {
       return [];
-    }
-
-    if (!options) {
-      options = {countSupplementaryCharacterAsOne: true};
     }
 
     var tags = [],
@@ -688,14 +666,18 @@ if (!window.twttr) {
       });
     });
 
-    if (options.countSupplementaryCharacterAsOne) {
-      twttr.txt.adjustIndices(text, tags, -1);
-    }
-
     return tags;
   };
 
-  twttr.txt.adjustIndices = function(text, entities, diff) {
+  twttr.txt.modifyIndicesFromUnicodeToUTF16 = function(text, entities) {
+    twttr.txt.shiftIndices(text, entities, 1);
+  };
+
+  twttr.txt.modifyIndicesFromUTF16ToUnicode = function(text, entities) {
+    twttr.txt.shiftIndices(text, entities, -1);
+  };
+
+  twttr.txt.shiftIndices = function(text, entities, diff) {
     for (var i = 0; i < text.length - 1; i++) {
       var c1 = text.charCodeAt(i);
       var c2 = text.charCodeAt(i + 1);
@@ -709,7 +691,7 @@ if (!window.twttr) {
         }
       }
     }
-  }
+  };
 
   // this essentially does text.split(/<|>/)
   // except that won't work in IE, where empty strings are ommitted

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -440,7 +440,7 @@ if (!window.twttr) {
   };
 
   twttr.txt.autoLink = function(text, options) {
-    var entities = twttr.txt.extractEntitiesWithIndices(text, {extractUrlWithoutProtocol: false});
+    var entities = twttr.txt.extractEntitiesWithIndices(text, {extractUrlWithoutProtocol: false, countSupplementaryCharacterAsOne: false});
     return twttr.txt.autoLinkEntities(text, entities, options);
   };
 
@@ -461,8 +461,8 @@ if (!window.twttr) {
 
   twttr.txt.extractEntitiesWithIndices = function(text, options) {
     var entities = twttr.txt.extractUrlsWithIndices(text, options)
-                   .concat(twttr.txt.extractMentionsOrListsWithIndices(text))
-                   .concat(twttr.txt.extractHashtagsWithIndices(text));
+                   .concat(twttr.txt.extractMentionsOrListsWithIndices(text, options))
+                   .concat(twttr.txt.extractHashtagsWithIndices(text, options));
 
     if (entities.length == 0) {
       return [];
@@ -495,7 +495,11 @@ if (!window.twttr) {
     return screenNamesOnly;
   };
 
-  twttr.txt.extractMentionsWithIndices = function(text) {
+  twttr.txt.extractMentionsWithIndices = function(text, options) {
+    if (!options) {
+      options = {countSupplementaryCharacterAsOne: true};
+    }
+
     var mentions = [];
     var mentionsOrLists = twttr.txt.extractMentionsOrListsWithIndices(text);
 
@@ -509,6 +513,9 @@ if (!window.twttr) {
       }
     }
 
+    if (options.countSupplementaryCharacterAsOne) {
+      twttr.txt.adjustIndices(text, mentions, -1);
+    }
     return mentions;
   };
 
@@ -516,9 +523,13 @@ if (!window.twttr) {
    * Extract list or user mentions.
    * (Presence of listSlug indicates a list)
    */
-  twttr.txt.extractMentionsOrListsWithIndices = function(text) {
+  twttr.txt.extractMentionsOrListsWithIndices = function(text, options) {
     if (!text || !text.match(twttr.txt.regexen.atSign)) {
       return [];
+    }
+
+    if (!options) {
+      options = {countSupplementaryCharacterAsOne: true};
     }
 
     var possibleNames = [],
@@ -538,6 +549,9 @@ if (!window.twttr) {
       }
     });
 
+    if (options.countSupplementaryCharacterAsOne) {
+      twttr.txt.adjustIndices(text, possibleNames, -1);
+    }
     return possibleNames;
   };
 
@@ -569,7 +583,7 @@ if (!window.twttr) {
 
   twttr.txt.extractUrlsWithIndices = function(text, options) {
     if (!options) {
-      options = {extractUrlsWithoutProtocol: true};
+      options = {extractUrlsWithoutProtocol: true, countSupplementaryCharacterAsOne: true};
     }
 
     if (!text || (options.extractUrlsWithoutProtocol ? !text.match(/\./) : !text.match(/:/))) {
@@ -632,6 +646,10 @@ if (!window.twttr) {
       }
     });
 
+    if (options.countSupplementaryCharacterAsOne) {
+      twttr.txt.adjustIndices(text, urls, -1);
+    }
+
     return urls;
   };
 
@@ -646,9 +664,13 @@ if (!window.twttr) {
     return hashtagsOnly;
   };
 
-  twttr.txt.extractHashtagsWithIndices = function(text) {
+  twttr.txt.extractHashtagsWithIndices = function(text, options) {
     if (!text || !text.match(twttr.txt.regexen.hashSigns)) {
       return [];
+    }
+
+    if (!options) {
+      options = {countSupplementaryCharacterAsOne: true};
     }
 
     var tags = [],
@@ -666,8 +688,28 @@ if (!window.twttr) {
       });
     });
 
+    if (options.countSupplementaryCharacterAsOne) {
+      twttr.txt.adjustIndices(text, tags, -1);
+    }
+
     return tags;
   };
+
+  twttr.txt.adjustIndices = function(text, entities, diff) {
+    for (var i = 0; i < text.length - 1; i++) {
+      var c1 = text.charCodeAt(i);
+      var c2 = text.charCodeAt(i + 1);
+      if (0xD800 <= c1 && c1 <= 0xDBFF && 0xDC00 <= c2 && c2 <= 0xDFFF) {
+        // supplementary character
+        for (var j = 0; j < entities.length; j++) {
+          if (entities[j].indices[0] >= i) {
+            entities[j].indices[0] += diff;
+            entities[j].indices[1] += diff;
+          }
+        }
+      }
+    }
+  }
 
   // this essentially does text.split(/<|>/)
   // except that won't work in IE, where empty strings are ommitted


### PR DESCRIPTION
extract*() in twitter-text-js extracts entities with UTF-16 based indices where Unicode supplementary characters are counted as two characters.

However, Twitter API and twitter-text-rb produces indices based on Unicode where Unicode supplementary characters are counted as single characters.

This will add 2 new methods, twttr.txt.modifyIndicesFromUTF16ToUnicode() and twttr.txt.modifyIndicesFromUnicodeToUTF16(), which can be used to modify indices from UTF-16 based to Unicode based, and vise versa.
