### PR TITLE
Bug fix: extract correct indices from text with duplicate URLs.

### DIFF
--- a/twitter-text.js
+++ b/twitter-text.js
@@ -579,16 +579,17 @@ if (!window.twttr) {
     var urls = [],
         position = 0;
 
-    text.replace(twttr.txt.regexen.extractUrl, function(match, all, before, url, protocol, domain, port, path, query) {
-      var startPosition = text.indexOf(url, position),
-          endPosition = startPosition + url.length;
+    while (twttr.txt.regexen.extractUrl.exec(text)) {
+      var before = RegExp.$2, url = RegExp.$3, protocol = RegExp.$4, domain = RegExp.$5, path = RegExp.$7;
+      var endPosition = twttr.txt.regexen.extractUrl.lastIndex,
+          startPosition = endPosition - url.length;
 
       // if protocol is missing and domain contains non-ASCII characters,
       // extract ASCII-only domains.
       if (!protocol) {
         if (!options.extractUrlsWithoutProtocol
             || before.match(twttr.txt.regexen.invalidUrlWithoutProtocolPrecedingChars)) {
-          return;
+          continue;
         }
         var lastUrl = null,
             lastUrlInvalidMatch = false,
@@ -608,7 +609,7 @@ if (!window.twttr) {
 
         // no ASCII-only domain found. Skip the entire URL.
         if (lastUrl == null) {
-          return;
+          continue;
         }
 
         // lastUrl only contains domain. Need to add path and query if they exist.
@@ -630,7 +631,7 @@ if (!window.twttr) {
           indices: [startPosition, endPosition]
         });
       }
-    });
+    }
 
     return urls;
   };


### PR DESCRIPTION
This fixes a bug reported in https://github.com/twitter/twitter-text-conformance/pull/30
