### PR TITLE
Refactor twttr.txt.autoLinkEntities()

### DIFF
--- a/test/conformance.html
+++ b/test/conformance.html
@@ -119,6 +119,8 @@
     }
 
 
+    var expected = document.createElement("div");
+    var result = document.createElement("div");
     for (var suite in cases) {
       (function(suite) {
         module(suite);
@@ -128,7 +130,14 @@
             var tester = getTester(suite, section);
             test(section, function() {
               for (var testCase in cases[suite][section]) {
-                same(tester(cases[suite][section][testCase]), cases[suite][section][testCase].expected, cases[suite][section][testCase].description);
+                if (suite == "autolink") {
+                  // compare HTML tags w/o checking attribute order
+                  result.innerHTML = tester(cases[suite][section][testCase]);
+                  expected.innerHTML = cases[suite][section][testCase].expected;
+                  ok(result.isEqualNode(expected), cases[suite][section][testCase].description);
+                } else {
+                  same(tester(cases[suite][section][testCase]), cases[suite][section][testCase].expected, cases[suite][section][testCase].description);
+                }
               }
             });
           }(section));

--- a/test/tests.js
+++ b/test/tests.js
@@ -98,13 +98,17 @@ test("twttr.txt.extract", function() {
 });
 
 test("twttr.txt.autolink", function() {
+  var expected = document.createElement("div");
+  var result = document.createElement("div");
+
   // Username Overrides
   ok(twttr.txt.autoLink("@tw", { before: "!" }).match(/!@<a[^>]+>tw<\/a>/), "Override before");
   ok(twttr.txt.autoLink("@tw", { at: "!" }).match(/!<a[^>]+>tw<\/a>/), "Override at");
   ok(twttr.txt.autoLink("@tw", { preChunk: "<b>" }).match(/@<a[^>]+><b>tw<\/a>/), "Override preChunk");
   ok(twttr.txt.autoLink("@tw", { postChunk: "</b>" }).match(/@<a[^>]+>tw<\/b><\/a>/), "Override postChunk");
-  same(twttr.txt.autoLink("@tw", { usernameIncludeSymbol: true }), "<a class=\"tweet-url username\" data-screen-name=\"tw\" href=\"https://twitter.com/tw\" rel=\"nofollow\">@tw</a>",
-      "Include @ in the autolinked username");
+  expected.innerHTML = "<a class=\"tweet-url username\" data-screen-name=\"tw\" href=\"https://twitter.com/tw\" rel=\"nofollow\">@tw</a>";
+  result.innerHTML = twttr.txt.autoLink("@tw", { usernameIncludeSymbol: true });
+  ok(expected.isEqualNode(result), "Include @ in the autolinked username");
   ok(!twttr.txt.autoLink("foo http://example.com", { usernameClass: 'custom-user' }).match(/custom-user/), "Override usernameClass should not be applied to URL");
 
   // List Overrides
@@ -112,8 +116,9 @@ test("twttr.txt.autolink", function() {
   ok(twttr.txt.autoLink("@tw/somelist", { at: "!" }).match(/!<a[^>]+>tw\/somelist<\/a>/), "Override list at");
   ok(twttr.txt.autoLink("@tw/somelist", { preChunk: "<b>" }).match(/@<a[^>]+><b>tw\/somelist<\/a>/), "Override list preChunk");
   ok(twttr.txt.autoLink("@tw/somelist", { postChunk: "</b>" }).match(/@<a[^>]+>tw\/somelist<\/b><\/a>/), "Override list postChunk");
-  same(twttr.txt.autoLink("@tw/somelist", { usernameIncludeSymbol: true }), "<a class=\"tweet-url list-slug\" href=\"https://twitter.com/tw/somelist\" rel=\"nofollow\">@tw/somelist</a>",
-      "Include @ in the autolinked list");
+  expected.innerHTML = "<a class=\"tweet-url list-slug\" href=\"https://twitter.com/tw/somelist\" rel=\"nofollow\">@tw/somelist</a>";
+  result.innerHTML = twttr.txt.autoLink("@tw/somelist", { usernameIncludeSymbol: true });
+  ok(expected.isEqualNode(result), "Include @ in the autolinked list");
   ok(twttr.txt.autoLink("foo @tw/somelist", { listClass: 'custom-list' }).match(/custom-list/), "Override listClass");
   ok(!twttr.txt.autoLink("foo @tw/somelist", { usernameClass: 'custom-user' }).match(/custom-user/), "Override usernameClass should not be applied to a List");
 
@@ -135,7 +140,7 @@ test("twttr.txt.autolink", function() {
       ]
     }]
   });
-  ok(autoLinkResult.match(/<a href="http:\/\/t.co\/0JG5Mcq"[^>]+>/), 'Use t.co URL as link target');
+  ok(autoLinkResult.match(/href="http:\/\/t.co\/0JG5Mcq"/), 'Use t.co URL as link target');
   ok(autoLinkResult.match(/>blog.twitter.com\/2011\/05\/twitte.*…</), 'Use display url from url entities');
   ok(autoLinkResult.match(/r-for-mac-update.html</), 'Include the tail of expanded_url');
   ok(autoLinkResult.match(/>http:\/\//), 'Include the head of expanded_url');
@@ -151,17 +156,17 @@ test("twttr.txt.autolink", function() {
 
   // urls with invalid character
   var invalidChars = ['\u202A', '\u202B', '\u202C', '\u202D', '\u202E'];
-  for (i = 0; i < invalidChars.length; i++) {
+  for (var i = 0; i < invalidChars.length; i++) {
     equal(twttr.txt.extractUrls("http://twitt" + invalidChars[i] + "er.com").length, 0, 'Should not extract URL with invalid character');
   }
 
-  same(twttr.txt.autoLink("\uD801\uDC00 #hashtag \uD801\uDC00 @mention \uD801\uDC00 http://twitter.com"),
-      "\uD801\uDC00 <a href=\"https://twitter.com/#!/search?q=%23hashtag\" title=\"#hashtag\" class=\"tweet-url hashtag\" rel=\"nofollow\">#hashtag</a> \uD801\uDC00 @<a class=\"tweet-url username\" data-screen-name=\"mention\" href=\"https://twitter.com/mention\" rel=\"nofollow\">mention</a> \uD801\uDC00 <a href=\"http://twitter.com\" rel=\"nofollow\" >http://twitter.com</a>",
-      "Autolink hashtag/mentionURL w/ Supplementary character");
+  expected.innerHTML = "\uD801\uDC00 <a class=\"tweet-url hashtag\" href=\"https://twitter.com/#!/search?q=%23hashtag\" rel=\"nofollow\" title=\"#hashtag\">#hashtag</a> \uD801\uDC00 @<a class=\"tweet-url username\" data-screen-name=\"mention\" href=\"https://twitter.com/mention\" rel=\"nofollow\">mention</a> \uD801\uDC00 <a href=\"http://twitter.com\" rel=\"nofollow\">http://twitter.com</a>";
+  result.innerHTML = twttr.txt.autoLink("\uD801\uDC00 #hashtag \uD801\uDC00 @mention \uD801\uDC00 http://twitter.com");
+  ok(expected.isEqualNode(result), "Autolink hashtag/mentionURL w/ Supplementary character");
 });
 
 test("twttr.txt.extractMentionsOrListsWithIndices", function() {
-  var invalid_chars = ['!', '@', '#', '$', '%', '&', '*']
+  var invalid_chars = ['!', '@', '#', '$', '%', '&', '*'];
 
   for (var i = 0; i < invalid_chars.length; i++) {
     c = invalid_chars[i];


### PR DESCRIPTION
This is a refactoring of twttr.txt.autoLinkEntities() based on 
https://github.com/twitter/twitter-text-rb/pull/42
- split autoLinkEntities() method into linkTo{URL,Hashtag,UsernameAndList}() methods, which all call to linkTo() method.
- escape all tag attributes.
- change unit tests and conformance tests to ignore the order of tag attributes.
