### PR TITLE
Modify extractHashtagsWithIndices() to not extract a hashtag if it's a part of URL.

### DIFF
--- a/twitter-text.js
+++ b/twitter-text.js
@@ -602,15 +602,7 @@ if (typeof twttr === "undefined" || twttr === null) {
     return twttr.txt.autoLinkEntities(text, entities, options);
   };
 
-  twttr.txt.extractEntitiesWithIndices = function(text, options) {
-    var entities = twttr.txt.extractUrlsWithIndices(text, options)
-                    .concat(twttr.txt.extractMentionsOrListsWithIndices(text))
-                    .concat(twttr.txt.extractHashtagsWithIndices(text));
-
-    if (entities.length == 0) {
-      return [];
-    }
-
+  twttr.txt.removeOverlappingEntities = function(entities) {
     entities.sort(function(a,b){ return a.indices[0] - b.indices[0]; });
 
     var prev = entities[0];
@@ -622,7 +614,18 @@ if (typeof twttr === "undefined" || twttr === null) {
         prev = entities[i];
       }
     }
+  };
 
+  twttr.txt.extractEntitiesWithIndices = function(text, options) {
+    var entities = twttr.txt.extractUrlsWithIndices(text, options)
+                    .concat(twttr.txt.extractMentionsOrListsWithIndices(text))
+                    .concat(twttr.txt.extractHashtagsWithIndices(text, {checkUrlOverlap: false}));
+
+    if (entities.length == 0) {
+      return [];
+    }
+
+    twttr.txt.removeOverlappingEntities(entities);
     return entities;
   };
 
@@ -789,7 +792,11 @@ if (typeof twttr === "undefined" || twttr === null) {
     return hashtagsOnly;
   };
 
-  twttr.txt.extractHashtagsWithIndices = function(text) {
+  twttr.txt.extractHashtagsWithIndices = function(text, options) {
+    if (!options) {
+      options = {checkUrlOverlap: true};
+    }
+
     if (!text || !text.match(twttr.txt.regexen.hashSigns)) {
       return [];
     }
@@ -808,6 +815,20 @@ if (typeof twttr === "undefined" || twttr === null) {
         indices: [startPosition, position]
       });
     });
+
+    if (options.checkUrlOverlap) {
+      // also extract URL entities
+      var entities = tags.concat(twttr.txt.extractUrlsWithIndices(text));
+      // remove overlap
+      twttr.txt.removeOverlappingEntities(entities);
+      // only push back hashtags
+      tags = [];
+      for (var i = 0; i < entities.length; i++) {
+        if (entities[i].hashtag) {
+          tags.push(entities[i]);
+        }
+      }
+    }
 
     return tags;
   };

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -818,14 +818,17 @@ if (typeof twttr === "undefined" || twttr === null) {
 
     if (options.checkUrlOverlap) {
       // also extract URL entities
-      var entities = tags.concat(twttr.txt.extractUrlsWithIndices(text));
-      // remove overlap
-      twttr.txt.removeOverlappingEntities(entities);
-      // only push back hashtags
-      tags = [];
-      for (var i = 0; i < entities.length; i++) {
-        if (entities[i].hashtag) {
-          tags.push(entities[i]);
+      var urls = twttr.txt.extractUrlsWithIndices(text);
+      if (urls.length > 0) {
+        var entities = tags.concat(urls);
+        // remove overlap
+        twttr.txt.removeOverlappingEntities(entities);
+        // only push back hashtags
+        tags = [];
+        for (var i = 0; i < entities.length; i++) {
+          if (entities[i].hashtag) {
+            tags.push(entities[i]);
+          }
         }
       }
     }


### PR DESCRIPTION
The current extractHashtagsWithIndices() extracts hashtags which are part of URL. E.g., it extracts "#hashtag" from "http://twitter.com/#hashtag".

This fixes the bug by adding an option in extractHashtagsWithIndices() called checkUrlOverlap. If it's set as true (which is a default value), extractHashtagsWithIndices() checks if any extracted hashtag overlaps with any URL in the text, and removes overlapping one.
