### PR TITLE
Fix spell miss

### DIFF
--- a/twitter-text.js
+++ b/twitter-text.js
@@ -663,7 +663,7 @@ if (typeof twttr === "undefined" || twttr === null) {
    * (Presence of listSlug indicates a list)
    */
   twttr.txt.extractMentionsOrListsWithIndices = function(text) {
-    if (!text || !text.match(twttr.txt.regexen.atSign)) {
+    if (!text || !text.match(twttr.txt.regexen.atSigns)) {
       return [];
     }
 


### PR DESCRIPTION
Because of `atSign` and `atSigns` are different, tests fail on Firefox.
