### PR TITLE
Modify tweet_length to count URL as 20/21 chars

### DIFF
--- a/test/conformance.html
+++ b/test/conformance.html
@@ -113,6 +113,10 @@
               return function(test) {
                 return twttr.txt.isValidUrl(test.text, true, false);
               };
+            case "lengths":
+              return function(test) {
+                return twttr.txt.getTweetLength(test.text);
+              };
           }
       }
 

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -1019,18 +1019,31 @@ if (typeof twttr === "undefined" || twttr === null) {
     fromCode(0x202D),
     fromCode(0x202E)
   ];
-  
+
   // Returns the length of Tweet text with consideration to t.co URL replacement
-  twttr.txt.getLengthWithWrappedUrls = function(text) {
+  twttr.txt.getTweetLength = function(text, options) {
+    if (!options) {
+      options = {
+          short_url_length: 20,
+          short_url_length_https: 21
+      };
+    }
     var textLength = text.length;
     var urlsWithIndices = twttr.txt.extractUrlsWithIndices(text);
-    
+
     for (var i = 0; i < urlsWithIndices.length; i++) {
     	// Subtract the length of the original URL
-    	// Add 20 characters to account for a t.co URL
-    	textLength += urlsWithIndices[i].indices[0] - urlsWithIndices[i].indices[1] + 20;
+      textLength += urlsWithIndices[i].indices[0] - urlsWithIndices[i].indices[1];
+
+      // Add 21 characters for URL starting with https://
+      // Otherwise add 20 characters
+      if (urlsWithIndices[i].url.toLowerCase().match(/^https:\/\//)) {
+         textLength += options.short_url_length_https;
+      } else {
+        textLength += options.short_url_length;
+      }
     }
-    
+
     return textLength;
   };
 
@@ -1049,7 +1062,7 @@ if (typeof twttr === "undefined" || twttr === null) {
     }
 
     // Determine max length independent of URL length
-    if (twttr.txt.getLengthWithWrappedUrls(text) > MAX_LENGTH) {
+    if (twttr.txt.getTweetLength(text) > MAX_LENGTH) {
       return "too_long";
     }
 

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -777,6 +777,20 @@ if (!window.twttr) {
     fromCode(0x202D),
     fromCode(0x202E)
   ];
+  
+  // Returns the length of Tweet text with consideration to t.co URL replacement
+  twttr.txt.getLengthWithWrappedUrls = function(text) {
+    var textLength = text.length;
+    var urlsWithIndices = twttr.txt.extractUrlsWithIndices(text);
+    
+    for (var i = 0; i < urlsWithIndices.length; i++) {
+    	// Subtract the length of the original URL
+    	// Add 20 characters to account for a t.co URL
+    	textLength += urlsWithIndices[i].indices[0] - urlsWithIndices[i].indices[1] + 20;
+    }
+    
+    return textLength;
+  };
 
   // Check the text for any reason that it may not be valid as a Tweet. This is meant as a pre-validation
   // before posting to api.twitter.com. There are several server-side reasons for Tweets to fail but this pre-validation
@@ -792,7 +806,8 @@ if (!window.twttr) {
       return "empty";
     }
 
-    if (text.length > MAX_LENGTH) {
+    // Determine max length independent of URL length
+    if (twttr.txt.getLengthWithWrappedUrls(text) > MAX_LENGTH) {
       return "too_long";
     }
 


### PR DESCRIPTION
This is based on the pull request https://github.com/twitter/twitter-text-js/pull/19

I modified it such that getTweetLength() counts HTTP or protocol-less URL as 20 characters and HTTPS URL as 21 characters.
