### PR TITLE
Add support for extracting/auto-linking cashtags

### DIFF
--- a/test/conformance.html
+++ b/test/conformance.html
@@ -31,6 +31,10 @@
               return function(test) {
                 return twttr.txt.autoLinkUsernamesOrLists(test.text, {suppressNoFollow: true, suppressDataScreenName: true});
               };
+            case "cashtags":
+              return function(test) {
+                return twttr.txt.autoLinkCashtags(test.text, {suppressNoFollow: true, suppressDataScreenName: true});
+              };
             case "all":
               return function(test) {
                 return twttr.txt.autoLink(test.text, {suppressNoFollow: true, suppressDataScreenName: true});
@@ -81,6 +85,14 @@
             case "hashtags_with_indices":
               return function(test) {
                 return twttr.txt.extractHashtagsWithIndices(test.text);
+              };
+            case "cashtags":
+              return function(test) {
+                return twttr.txt.extractCashtags(test.text);
+              };
+            case "cashtags_with_indices":
+              return function(test) {
+                return twttr.txt.extractCashtagsWithIndices(test.text);
               };
           }
         case "hit_highlighting":


### PR DESCRIPTION
This is modifying twitter-text-js to extract $cashtag as entities and also to auto-link $cashtag as a link to a search page.
