### PR TITLE
Add new options to Autolink

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -124,7 +124,7 @@ test("twttr.txt.autolink", function() {
 
   // test urlClass
   same(twttr.txt.autoLink("http://twitter.com"), "<a href=\"http://twitter.com\" rel=\"nofollow\">http://twitter.com</a>", "AutoLink without urlClass");
-  same(twttr.txt.autoLink("http://twitter.com", {urlClass: "testClass"}), "<a href=\"http://twitter.com\" rel=\"nofollow\" class=\"testClass\">http://twitter.com</a>", "autoLink with urlClass");
+  same(twttr.txt.autoLink("http://twitter.com", {urlClass: "testClass"}), "<a href=\"http://twitter.com\" class=\"testClass\" rel=\"nofollow\">http://twitter.com</a>", "autoLink with urlClass");
   ok(!twttr.txt.autoLink("#hash @tw", {urlClass: "testClass"}).match(/class=\"testClass\"/), "urlClass won't be used for hashtag and @mention auto-links");
 
   // test urlTarget
@@ -133,6 +133,16 @@ test("twttr.txt.autolink", function() {
   ok(!autoLinkResult.match(/<a[^>]+username[^>]+target[^>]+>/), "urlTarget shouldn't be applied to auto-linked mention");
   ok(autoLinkResult.match(/<a[^>]+test.com[^>]+target=\"_blank\"[^>]*>/), "urlTarget should be applied to auto-linked URL");
   ok(!autoLinkResult.match(/urlClass/i), "urlClass should not appear in HTML");
+
+  // test htmlAttributeBlock
+  autoLinkResult = twttr.txt.autoLink("#hash @mention", {htmlAttributeBlock: function(entity, attributes) {if (entity.hashtag) attributes["dummy-hash-attr"] = "test";}});
+  ok(autoLinkResult.match(/<a[^>]+hashtag[^>]+dummy-hash-attr=\"test\"[^>]+>/), "htmlAttributeBlock should be applied to hashtag");
+  ok(!autoLinkResult.match(/<a[^>]+username[^>]+dummy-hash-attr=\"test\"[^>]+>/), "htmlAttributeBlock should not be applied to mention");
+  ok(!autoLinkResult.match(/html_attribute_block/i), "htmlAttributeBlock should not appear in HTML");
+
+  autoLinkResult = twttr.txt.autoLink("@mention http://twitter.com/", {htmlAttributeBlock: function(entity, attributes) {if (entity.url) attributes["dummy-url-attr"] = entity.url;}});
+  ok(!autoLinkResult.match(/<a[^>]+username[^>]+dummy-hash-attr=\"test\"[^>]+>/), "htmlAttributeBlock should not be applied to mention");
+  ok(autoLinkResult.match(/<a[^>]+dummy-url-attr=\"http:\/\/twitter.com\/\"/), "htmlAttributeBlock should be applied to URL");
 
   // url entities
   autoLinkResult = twttr.txt.autoLink("http://t.co/0JG5Mcq", {

--- a/test/tests.js
+++ b/test/tests.js
@@ -134,15 +134,34 @@ test("twttr.txt.autolink", function() {
   ok(autoLinkResult.match(/<a[^>]+test.com[^>]+target=\"_blank\"[^>]*>/), "urlTarget should be applied to auto-linked URL");
   ok(!autoLinkResult.match(/urlClass/i), "urlClass should not appear in HTML");
 
-  // test htmlAttributeBlock
-  autoLinkResult = twttr.txt.autoLink("#hash @mention", {htmlAttributeBlock: function(entity, attributes) {if (entity.hashtag) attributes["dummy-hash-attr"] = "test";}});
-  ok(autoLinkResult.match(/<a[^>]+hashtag[^>]+dummy-hash-attr=\"test\"[^>]+>/), "htmlAttributeBlock should be applied to hashtag");
-  ok(!autoLinkResult.match(/<a[^>]+username[^>]+dummy-hash-attr=\"test\"[^>]+>/), "htmlAttributeBlock should not be applied to mention");
-  ok(!autoLinkResult.match(/html_attribute_block/i), "htmlAttributeBlock should not appear in HTML");
+  // test linkAttributeBlock
+  autoLinkResult = twttr.txt.autoLink("#hash @mention", {linkAttributeBlock: function(entity, attributes) {if (entity.hashtag) attributes["dummy-hash-attr"] = "test";}});
+  ok(autoLinkResult.match(/<a[^>]+hashtag[^>]+dummy-hash-attr=\"test\"[^>]*>/), "linkAttributeBlock should be applied to hashtag");
+  ok(!autoLinkResult.match(/<a[^>]+username[^>]+dummy-hash-attr=\"test\"[^>]*>/), "linkAttributeBlock should not be applied to mention");
+  ok(!autoLinkResult.match(/linkAttributeBlock/i), "linkAttributeBlock should not appear in HTML");
 
-  autoLinkResult = twttr.txt.autoLink("@mention http://twitter.com/", {htmlAttributeBlock: function(entity, attributes) {if (entity.url) attributes["dummy-url-attr"] = entity.url;}});
-  ok(!autoLinkResult.match(/<a[^>]+username[^>]+dummy-hash-attr=\"test\"[^>]+>/), "htmlAttributeBlock should not be applied to mention");
-  ok(autoLinkResult.match(/<a[^>]+dummy-url-attr=\"http:\/\/twitter.com\/\"/), "htmlAttributeBlock should be applied to URL");
+  autoLinkResult = twttr.txt.autoLink("@mention http://twitter.com/", {linkAttributeBlock: function(entity, attributes) {if (entity.url) attributes["dummy-url-attr"] = entity.url;}});
+  ok(!autoLinkResult.match(/<a[^>]+username[^>]+dummy-hash-attr=\"test\"[^>]*>/), "linkAttributeBlock should not be applied to mention");
+  ok(autoLinkResult.match(/<a[^>]+dummy-url-attr=\"http:\/\/twitter.com\/\"/), "linkAttributeBlock should be applied to URL");
+
+  // test linkTextBlock
+  autoLinkResult = twttr.txt.autoLink("#hash @mention", {
+      linkTextBlock: function(entity, text) {
+        return entity.hashtag ? "#replaced" : "pre_" + text + "_post";
+      }
+  });
+  ok(autoLinkResult.match(/<a[^>]+>#replaced<\/a>/), "linkTextBlock should modify a hashtag link text");
+  ok(autoLinkResult.match(/<a[^>]+>pre_mention_post<\/a>/), "linkTextBlock should modify a username link text");
+  ok(!autoLinkResult.match(/linkTextBlock/i), "linkTextBlock should not appear in HTML");
+
+  autoLinkResult = twttr.txt.autoLink("#hash @mention", {
+    linkTextBlock: function(entity, text) {
+      return "pre_" + text +"_post";
+    },
+    symbolTag: "s", textWithSymbolTag: "b", usernameIncludeSymbol: true
+  });
+  ok(autoLinkResult.match(/<a[^>]+>pre_<s>#<\/s><b>hash<\/b>_post<\/a>/), "linkTextBlock should modify a hashtag link text");
+  ok(autoLinkResult.match(/<a[^>]+>pre_<s>@<\/s><b>mention<\/b>_post<\/a>/), "linkTextBlock should modify a username link text");
 
   // url entities
   autoLinkResult = twttr.txt.autoLink("http://t.co/0JG5Mcq", {

--- a/test/tests.js
+++ b/test/tests.js
@@ -125,10 +125,17 @@ test("twttr.txt.autolink", function() {
   // test urlClass
   same(twttr.txt.autoLink("http://twitter.com"), "<a href=\"http://twitter.com\" rel=\"nofollow\">http://twitter.com</a>", "AutoLink without urlClass");
   same(twttr.txt.autoLink("http://twitter.com", {urlClass: "testClass"}), "<a href=\"http://twitter.com\" rel=\"nofollow\" class=\"testClass\">http://twitter.com</a>", "autoLink with urlClass");
-  ok(!twttr.txt.autoLink("#hash @tw", {urlClass: "testClass"}).match(/class=\"testClass\"/), "urlClass won't be used for hashtag and @mention auto-links")
+  ok(!twttr.txt.autoLink("#hash @tw", {urlClass: "testClass"}).match(/class=\"testClass\"/), "urlClass won't be used for hashtag and @mention auto-links");
+
+  // test urlTarget
+  var autoLinkResult = twttr.txt.autoLink("#hashtag @mention http://test.com", {urlTarget:'_blank'});
+  ok(!autoLinkResult.match(/<a[^>]+hashtag[^>]+target[^>]+>/), "urlTarget shouldn't be applied to auto-linked hashtag");
+  ok(!autoLinkResult.match(/<a[^>]+username[^>]+target[^>]+>/), "urlTarget shouldn't be applied to auto-linked mention");
+  ok(autoLinkResult.match(/<a[^>]+test.com[^>]+target=\"_blank\"[^>]*>/), "urlTarget should be applied to auto-linked URL");
+  ok(!autoLinkResult.match(/urlClass/i), "urlClass should not appear in HTML");
 
   // url entities
-  var autoLinkResult = twttr.txt.autoLink("http://t.co/0JG5Mcq", {
+  autoLinkResult = twttr.txt.autoLink("http://t.co/0JG5Mcq", {
     invisibleTagAttrs: "style='font-size:0'",
     urlEntities: [{
       "url": "http://t.co/0JG5Mcq",

--- a/test/tests.js
+++ b/test/tests.js
@@ -99,29 +99,26 @@ test("twttr.txt.extract", function() {
 
 test("twttr.txt.autolink", function() {
   // Username Overrides
-  ok(twttr.txt.autoLink("@tw", { before: "!" }).match(/!@<a[^>]+>tw<\/a>/), "Override before");
-  ok(twttr.txt.autoLink("@tw", { at: "!" }).match(/!<a[^>]+>tw<\/a>/), "Override at");
-  ok(twttr.txt.autoLink("@tw", { preChunk: "<b>" }).match(/@<a[^>]+><b>tw<\/a>/), "Override preChunk");
-  ok(twttr.txt.autoLink("@tw", { postChunk: "</b>" }).match(/@<a[^>]+>tw<\/b><\/a>/), "Override postChunk");
-  same(twttr.txt.autoLink("@tw", { usernameIncludeSymbol: true }), "<a class=\"tweet-url username\" data-screen-name=\"tw\" href=\"https://twitter.com/tw\" rel=\"nofollow\">@tw</a>",
+  ok(twttr.txt.autoLink("@tw", { symbolTag: "s" }).match(/<s>@<\/s><a[^>]+>tw<\/a>/), "Apply symbolTag to @username");
+  ok(twttr.txt.autoLink("@tw", { textWithSymbolTag: "b" }).match(/@<a[^>]+><b>tw<\/b><\/a>/), "Apply textWithSymbolTag to @username");
+  ok(twttr.txt.autoLink("@tw", { symbolTag: "s", textWithSymbolTag: "b" }).match(/<s>@<\/s><a[^>]+><b>tw<\/b><\/a>/), "Apply symbolTag and textWithSymbolTag to @username");
+  same(twttr.txt.autoLink("@tw", { usernameIncludeSymbol: true }), "<a class=\"tweet-url username\" href=\"https://twitter.com/tw\" data-screen-name=\"tw\" rel=\"nofollow\">@tw</a>",
       "Include @ in the autolinked username");
   ok(!twttr.txt.autoLink("foo http://example.com", { usernameClass: 'custom-user' }).match(/custom-user/), "Override usernameClass should not be applied to URL");
 
   // List Overrides
-  ok(twttr.txt.autoLink("@tw/somelist", { before: "!" }).match(/!@<a[^>]+>tw\/somelist<\/a>/), "Override list before");
-  ok(twttr.txt.autoLink("@tw/somelist", { at: "!" }).match(/!<a[^>]+>tw\/somelist<\/a>/), "Override list at");
-  ok(twttr.txt.autoLink("@tw/somelist", { preChunk: "<b>" }).match(/@<a[^>]+><b>tw\/somelist<\/a>/), "Override list preChunk");
-  ok(twttr.txt.autoLink("@tw/somelist", { postChunk: "</b>" }).match(/@<a[^>]+>tw\/somelist<\/b><\/a>/), "Override list postChunk");
+  ok(twttr.txt.autoLink("@tw/somelist", { symbolTag: "s" }).match(/<s>@<\/s><a[^>]+>tw\/somelist<\/a>/), "Apply symbolTag to list");
+  ok(twttr.txt.autoLink("@tw/somelist", { textWithSymbolTag: "b" }).match(/@<a[^>]+><b>tw\/somelist<\/b><\/a>/), "apply textWithSymbolTag to list");
+  ok(twttr.txt.autoLink("@tw/somelist", { symbolTag: "s", textWithSymbolTag: "b" }).match(/<s>@<\/s><a[^>]+><b>tw\/somelist<\/b><\/a>/), "apply symbolTag and textWithSymbolTag to list");
   same(twttr.txt.autoLink("@tw/somelist", { usernameIncludeSymbol: true }), "<a class=\"tweet-url list-slug\" href=\"https://twitter.com/tw/somelist\" rel=\"nofollow\">@tw/somelist</a>",
       "Include @ in the autolinked list");
   ok(twttr.txt.autoLink("foo @tw/somelist", { listClass: 'custom-list' }).match(/custom-list/), "Override listClass");
   ok(!twttr.txt.autoLink("foo @tw/somelist", { usernameClass: 'custom-user' }).match(/custom-user/), "Override usernameClass should not be applied to a List");
 
   // Hashtag Overrides
-  ok(twttr.txt.autoLink("#hi", { before: "!" }).match(/!<a[^>]+>#hi<\/a>/), "Override before");
-  ok(twttr.txt.autoLink("#hi", { hash: "!" }).match(/<a[^>]+>!hi<\/a>/), "Override hash");
-  ok(twttr.txt.autoLink("#hi", { preText: "<b>" }).match(/<a[^>]+>#<b>hi<\/a>/), "Override preText");
-  ok(twttr.txt.autoLink("#hi", { postText: "</b>" }).match(/<a[^>]+>#hi<\/b><\/a>/), "Override postText");
+  ok(twttr.txt.autoLink("#hi", { symbolTag: "s" }).match(/<a[^>]+><s>#<\/s>hi<\/a>/), "Apply symbolTag to hash");
+  ok(twttr.txt.autoLink("#hi", { textWithSymbolTag: "b" }).match(/<a[^>]+>#<b>hi<\/b><\/a>/), "Apply textWithSymbolTag to hash");
+  ok(twttr.txt.autoLink("#hi", { symbolTag: "s", textWithSymbolTag: "b" }).match(/<a[^>]+><s>#<\/s><b>hi<\/b><\/a>/), "Apply symbolTag and textWithSymbolTag to hash");
 
   // url entities
   var autoLinkResult = twttr.txt.autoLink("http://t.co/0JG5Mcq", {
@@ -187,7 +184,7 @@ test("twttr.txt.autolink", function() {
   }
 
   same(twttr.txt.autoLink("\uD801\uDC00 #hashtag \uD801\uDC00 @mention \uD801\uDC00 http://twitter.com"),
-      "\uD801\uDC00 <a href=\"https://twitter.com/#!/search?q=%23hashtag\" title=\"#hashtag\" class=\"tweet-url hashtag\" rel=\"nofollow\">#hashtag</a> \uD801\uDC00 @<a class=\"tweet-url username\" data-screen-name=\"mention\" href=\"https://twitter.com/mention\" rel=\"nofollow\">mention</a> \uD801\uDC00 <a href=\"http://twitter.com\" rel=\"nofollow\" >http://twitter.com</a>",
+      "\uD801\uDC00 <a href=\"https://twitter.com/#!/search?q=%23hashtag\" title=\"#hashtag\" class=\"tweet-url hashtag\" rel=\"nofollow\">#hashtag</a> \uD801\uDC00 @<a class=\"tweet-url username\" href=\"https://twitter.com/mention\" data-screen-name=\"mention\" rel=\"nofollow\">mention</a> \uD801\uDC00 <a href=\"http://twitter.com\" rel=\"nofollow\">http://twitter.com</a>",
       "Autolink hashtag/mentionURL w/ Supplementary character");
 });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -123,6 +123,11 @@ test("twttr.txt.autolink", function() {
   ok(twttr.txt.autoLink("#hi", { preText: "<b>" }).match(/<a[^>]+>#<b>hi<\/a>/), "Override preText");
   ok(twttr.txt.autoLink("#hi", { postText: "</b>" }).match(/<a[^>]+>#hi<\/b><\/a>/), "Override postText");
 
+  // test urlClass
+  same(twttr.txt.autoLink("http://twitter.com"), "<a href=\"http://twitter.com\" rel=\"nofollow\" >http://twitter.com</a>", "AutoLink without urlClass");
+  same(twttr.txt.autoLink("http://twitter.com", {urlClass: "testClass"}), "<a href=\"http://twitter.com\" rel=\"nofollow\"  class=\"testClass\">http://twitter.com</a>", "autoLink with urlClass");
+  ok(!twttr.txt.autoLink("#hash @tw", {urlClass: "testClass"}).match(/class=\"testClass\"/), "urlClass won't be used for hashtag and @mention auto-links")
+
   // url entities
   var autoLinkResult = twttr.txt.autoLink("http://t.co/0JG5Mcq", {
     invisibleTagAttrs: "style='font-size:0'",

--- a/test/tests.js
+++ b/test/tests.js
@@ -100,7 +100,9 @@ test("twttr.txt.extract", function() {
 test("twttr.txt.autolink", function() {
   // Username Overrides
   ok(twttr.txt.autoLink("@tw", { symbolTag: "s" }).match(/<s>@<\/s><a[^>]+>tw<\/a>/), "Apply symbolTag to @username");
+  ok(!twttr.txt.autoLink("@tw", { symbolTag: "s" }).match(/symbolTag/i), "Do not include symbolTag attribute");
   ok(twttr.txt.autoLink("@tw", { textWithSymbolTag: "b" }).match(/@<a[^>]+><b>tw<\/b><\/a>/), "Apply textWithSymbolTag to @username");
+  ok(!twttr.txt.autoLink("@tw", { textWithSymbolTag: "b" }).match(/textWithSymbolTag/i), "Do not include textWithSymbolTag attribute");
   ok(twttr.txt.autoLink("@tw", { symbolTag: "s", textWithSymbolTag: "b" }).match(/<s>@<\/s><a[^>]+><b>tw<\/b><\/a>/), "Apply symbolTag and textWithSymbolTag to @username");
   same(twttr.txt.autoLink("@tw", { usernameIncludeSymbol: true }), "<a class=\"tweet-url username\" href=\"https://twitter.com/tw\" data-screen-name=\"tw\" rel=\"nofollow\">@tw</a>",
       "Include @ in the autolinked username");

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -381,7 +381,7 @@ if (typeof twttr === "undefined" || twttr === null) {
                             'usernameUrlBase':true, 'listUrlBase':true, 'hashtagUrlBase':true, 'cashtagUrlBase':true,
                             'usernameUrlBlock':true, 'listUrlBlock':true, 'hashtagUrlBlock':true, 'linkUrlBlock':true,
                             'usernameIncludeSymbol':true, 'suppressLists':true, 'suppressNoFollow':true,
-                            'suppressDataScreenName':true, 'urlEntities':true, 'before':true
+                            'suppressDataScreenName':true, 'urlEntities':true, 'symbolTag':true, 'textWithSymbolTag':true
                             };
   var BOOLEAN_ATTRIBUTES = {'disabled':true, 'readonly':true, 'multiple':true, 'checked':true};
 

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -368,16 +368,14 @@ if (typeof twttr === "undefined" || twttr === null) {
   , "i");
 
 
-  // Default CSS class for auto-linked URLs
-  var DEFAULT_URL_CLASS = "tweet-url";
   // Default CSS class for auto-linked lists (along with the url class)
-  var DEFAULT_LIST_CLASS = "list-slug";
+  var DEFAULT_LIST_CLASS = "tweet-url list-slug";
   // Default CSS class for auto-linked usernames (along with the url class)
-  var DEFAULT_USERNAME_CLASS = "username";
+  var DEFAULT_USERNAME_CLASS = "tweet-url username";
   // Default CSS class for auto-linked hashtags (along with the url class)
-  var DEFAULT_HASHTAG_CLASS = "hashtag";
+  var DEFAULT_HASHTAG_CLASS = "tweet-url hashtag";
   // Default CSS class for auto-linked cashtags (along with the url class)
-  var DEFAULT_CASHTAG_CLASS = "cashtag";
+  var DEFAULT_CASHTAG_CLASS = "tweet-url cashtag";
   // HTML attribute for robot nofollow behavior (default)
   var HTML_ATTR_NO_FOLLOW = " rel=\"nofollow\"";
   // Options which should not be passed as HTML attributes
@@ -415,7 +413,7 @@ if (typeof twttr === "undefined" || twttr === null) {
         }
       }
 
-      return stringSupplant("#{before}<a href=\"#{hashtagUrlBase}#{text}\" title=\"##{text}\" class=\"#{urlClass} #{hashtagClass}\"#{extraHtml}>#{hash}#{preText}#{text}#{postText}</a>", d);
+      return stringSupplant("#{before}<a href=\"#{hashtagUrlBase}#{text}\" title=\"##{text}\" class=\"#{hashtagClass}\"#{extraHtml}>#{hash}#{preText}#{text}#{postText}</a>", d);
   };
 
   twttr.txt.linkToCashtag = function(entity, text, options) {
@@ -431,7 +429,7 @@ if (typeof twttr === "undefined" || twttr === null) {
         }
       }
 
-      return stringSupplant("#{before}<a href=\"#{cashtagUrlBase}#{text}\" title=\"$#{text}\" class=\"#{urlClass} #{cashtagClass}\"#{extraHtml}>$#{preText}#{text}#{postText}</a>", d);
+      return stringSupplant("#{before}<a href=\"#{cashtagUrlBase}#{text}\" title=\"$#{text}\" class=\"#{cashtagClass}\"#{extraHtml}>$#{preText}#{text}#{postText}</a>", d);
   };
 
   twttr.txt.linkToMentionAndList = function(entity, text, options) {
@@ -455,12 +453,12 @@ if (typeof twttr === "undefined" || twttr === null) {
       // the link is a list
       var list = d.chunk = stringSupplant("#{user}#{slashListname}", d);
       d.list = twttr.txt.htmlEscape(list.toLowerCase());
-      return stringSupplant("#{before}#{at}<a class=\"#{urlClass} #{listClass}\" href=\"#{listUrlBase}#{list}\"#{extraHtml}>#{preChunk}#{at_before_user}#{chunk}#{postChunk}</a>", d);
+      return stringSupplant("#{before}#{at}<a class=\"#{listClass}\" href=\"#{listUrlBase}#{list}\"#{extraHtml}>#{preChunk}#{at_before_user}#{chunk}#{postChunk}</a>", d);
     } else {
       // this is a screen name
       d.chunk = d.user;
       d.dataScreenName = !options.suppressDataScreenName ? stringSupplant("data-screen-name=\"#{chunk}\" ", d) : "";
-      return stringSupplant("#{before}#{at}<a class=\"#{urlClass} #{usernameClass}\" #{dataScreenName}href=\"#{usernameUrlBase}#{chunk}\"#{extraHtml}>#{preChunk}#{at_before_user}#{chunk}#{postChunk}</a>", d);
+      return stringSupplant("#{before}#{at}<a class=\"#{usernameClass}\" #{dataScreenName}href=\"#{usernameUrlBase}#{chunk}\"#{extraHtml}>#{preChunk}#{at_before_user}#{chunk}#{postChunk}</a>", d);
     }
   };
 
@@ -478,6 +476,11 @@ if (typeof twttr === "undefined" || twttr === null) {
         options.htmlAttrs = (options.htmlAttrs || "") + " title=\"" + urlEntity.expanded_url + "\"";
       }
       linkText = twttr.txt.linkTextWithEntity(urlEntity, options);
+    }
+
+    // set class only if urlClass is specified.
+    if (options.urlClass) {
+      options.htmlAttrs = (options.htmlAttrs || "") + " class=\"" + options.urlClass + "\"";
     }
 
     var d = {
@@ -564,10 +567,6 @@ if (typeof twttr === "undefined" || twttr === null) {
     if (!options.suppressNoFollow) {
       options.rel = "nofollow";
     }
-    if (options.urlClass) {
-      options["class"] = options.urlClass;
-    }
-    options.urlClass = options.urlClass || DEFAULT_URL_CLASS;
     options.hashtagClass = options.hashtagClass || DEFAULT_HASHTAG_CLASS;
     options.hashtagUrlBase = options.hashtagUrlBase || "https://twitter.com/#!/search?q=%23";
     options.cashtagClass = options.cashtagClass || DEFAULT_CASHTAG_CLASS;

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -376,8 +376,6 @@ if (typeof twttr === "undefined" || twttr === null) {
   var DEFAULT_HASHTAG_CLASS = "tweet-url hashtag";
   // Default CSS class for auto-linked cashtags (along with the url class)
   var DEFAULT_CASHTAG_CLASS = "tweet-url cashtag";
-  // HTML attribute for robot nofollow behavior (default)
-  var HTML_ATTR_NO_FOLLOW = " rel=\"nofollow\"";
   // Options which should not be passed as HTML attributes
   var OPTIONS_NOT_ATTRIBUTES = {'urlClass':true, 'listClass':true, 'usernameClass':true, 'hashtagClass':true, 'cashtagClass':true,
                             'usernameUrlBase':true, 'listUrlBase':true, 'hashtagUrlBase':true, 'cashtagUrlBase':true,
@@ -414,7 +412,7 @@ if (typeof twttr === "undefined" || twttr === null) {
     } else {
       return stringSupplant("#{taggedSymbol}<a#{tagAttr}>#{taggedText}</a>", d);
     }
-  }
+  };
 
   twttr.txt.linkToHashtag = function(entity, text, options) {
     var hash = text.substring(entity.indices[0], entity.indices[0] + 1);

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -397,11 +397,15 @@ if (typeof twttr === "undefined" || twttr === null) {
     return r;
   }
 
-  twttr.txt.linkToTextWithSymbol = function(symbol, text, attributes, options) {
+  twttr.txt.linkToTextWithSymbol = function(entity, symbol, text, attributes, options) {
     var taggedSymbol = options.symbolTag ? "<" + options.symbolTag + ">" + symbol + "</"+ options.symbolTag + ">" : symbol;
     text = twttr.txt.htmlEscape(text);
     var taggedText = options.textWithSymbolTag ? "<" + options.textWithSymbolTag + ">" + text + "</"+ options.textWithSymbolTag + ">" : text;
 
+    // if htmlAttributeBlock is specified, call it to modify the attributes
+    if (options.htmlAttributeBlock) {
+      options.htmlAttributeBlock(entity, attributes);
+    }
     var d = {
       tagAttr: twttr.txt.extractHtmlAttrsFromOptions(attributes) + (options.htmlAttrs || ""),
       taggedSymbol: taggedSymbol,
@@ -423,7 +427,7 @@ if (typeof twttr === "undefined" || twttr === null) {
       class: options.hashtagClass
     };
 
-    return twttr.txt.linkToTextWithSymbol(hash, hashtag, attrs, options);
+    return twttr.txt.linkToTextWithSymbol(entity, hash, hashtag, attrs, options);
   };
 
   twttr.txt.linkToCashtag = function(entity, text, options) {
@@ -434,7 +438,7 @@ if (typeof twttr === "undefined" || twttr === null) {
       class: options.cashtagClass
     };
 
-    return twttr.txt.linkToTextWithSymbol("$", cashtag, attrs, options);
+    return twttr.txt.linkToTextWithSymbol(entity, "$", cashtag, attrs, options);
   };
 
   twttr.txt.linkToMentionAndList = function(entity, text, options) {
@@ -450,7 +454,7 @@ if (typeof twttr === "undefined" || twttr === null) {
       attrs['data-screen-name'] = user;
     }
 
-    return twttr.txt.linkToTextWithSymbol(at, isList ? user + slashListname : user, attrs, options);
+    return twttr.txt.linkToTextWithSymbol(entity, at, isList ? user + slashListname : user, attrs, options);
   };
 
   twttr.txt.linkToUrl = function(entity, text, options) {
@@ -466,18 +470,29 @@ if (typeof twttr === "undefined" || twttr === null) {
       linkText = twttr.txt.linkTextWithEntity(urlEntity, options);
     }
 
+    var attrs = {};
+
     // set class only if urlClass is specified.
     if (options.urlClass) {
-      options.htmlAttrs = (options.htmlAttrs || "") + " class=\"" + options.urlClass + "\"";
+      attrs["class"] = options.urlClass;
     }
 
     // set target only if urlTarget is specified.
     if (options.urlTarget) {
-      options.htmlAttrs = (options.htmlAttrs || "") + " target=\"" + options.urlTarget + "\"";
+      attrs.target = options.urlTarget;
+    }
+
+    if (!options.title && urlEntity.display_url) {
+      attrs.title = urlEntity.expanded_url;
+    }
+
+    // if htmlAttributeBlock is specified, call it to modify the attributes
+    if (options.htmlAttributeBlock) {
+      options.htmlAttributeBlock(entity, attrs);
     }
 
     var d = {
-      htmlAttrs: options.htmlAttrs + (!options.title && urlEntity.display_url ? " title=\"" + urlEntity.expanded_url + "\"" : ""),
+      htmlAttrs: twttr.txt.extractHtmlAttrsFromOptions(attrs) + (options.htmlAttrs || ""),
       url: twttr.txt.htmlEscape(url),
       linkText: linkText
     };

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -381,7 +381,7 @@ if (typeof twttr === "undefined" || twttr === null) {
                             'usernameUrlBase':true, 'listUrlBase':true, 'hashtagUrlBase':true, 'cashtagUrlBase':true,
                             'usernameUrlBlock':true, 'listUrlBlock':true, 'hashtagUrlBlock':true, 'linkUrlBlock':true,
                             'usernameIncludeSymbol':true, 'suppressLists':true, 'suppressNoFollow':true,
-                            'suppressDataScreenName':true, 'urlEntities':true, 'symbolTag':true, 'textWithSymbolTag':true
+                            'suppressDataScreenName':true, 'urlEntities':true, 'symbolTag':true, 'textWithSymbolTag':true, 'urlTarget':true
                             };
   var BOOLEAN_ATTRIBUTES = {'disabled':true, 'readonly':true, 'multiple':true, 'checked':true};
 
@@ -469,6 +469,11 @@ if (typeof twttr === "undefined" || twttr === null) {
     // set class only if urlClass is specified.
     if (options.urlClass) {
       options.htmlAttrs = (options.htmlAttrs || "") + " class=\"" + options.urlClass + "\"";
+    }
+
+    // set target only if urlTarget is specified.
+    if (options.urlTarget) {
+      options.htmlAttrs = (options.htmlAttrs || "") + " target=\"" + options.urlTarget + "\"";
     }
 
     var d = {


### PR DESCRIPTION
This will add the following options to Autolink.
- symbolTag: a tag to apply around symbol (#,@,$) in hashtag/username/list/cashtag links. 
- textWithSymbolTag: a tag to apply around text part in hashtag/username/list/cashtag links.
- urlTarget: the value of target attribute in URL links
- linkAttributeBlock: a block/function to modify attributes of a link based on the entity.
- linkTextBlock: a block/function to modify text of a link based on the entity.

Examples:

```
  autoLink("#hash", {symbol_tag: "s"}) => "<a...><s>#</s>hash</a>"
  autoLink("#hash", {textWithSymbolTag: "b"}) => "<a...>#<b>hash</b></a>"
  autoLink("#hash", {linkAttributeBlock: function(entity, attributes){
     if (entity.hashtag) { attributes["custom-attr"] = "some_value"; }
  }) => "<a.. custom-attr="some_value"...>#hash</a>"
  autoLink("#hash", {linkTextBlock: function(entity, text){
     return entity.hashtag ? "prefix"+text : text;
  }) => "<a...>prefix#text</a>"
```

This will also change urlClass option, which is currently applied to all links but will only be applied to URL links.

before, preChunk, postChunk, preText, postText, at and hash options will no longer be available as they are not available in twitter-text-rb/java and they can be replaced by those new options.
