### PR TITLE
Add an autolink option to htmlEscape the non-entities in a tweet

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -122,6 +122,13 @@ test("twttr.txt.autolink", function() {
   ok(twttr.txt.autoLink("#hi", { textWithSymbolTag: "b" }).match(/<a[^>]+>#<b>hi<\/b><\/a>/), "Apply textWithSymbolTag to hash");
   ok(twttr.txt.autoLink("#hi", { symbolTag: "s", textWithSymbolTag: "b" }).match(/<a[^>]+><s>#<\/s><b>hi<\/b><\/a>/), "Apply symbolTag and textWithSymbolTag to hash");
 
+  // htmlEscapeNonEntities
+  same(twttr.txt.autoLink("&<>\"'"), "&<>\"'", "Don't escape non-entities by default");
+  same(twttr.txt.autoLink("&<>\"'", { htmlEscapeNonEntities: true } ), "&amp;&lt;&gt;&quot;&#39;", "Escape non-entities");
+  same(twttr.txt.autoLink("& http://twitter.com/?a&b &", { htmlEscapeNonEntities: true }),
+      "&amp; <a href=\"http://twitter.com/?a&amp;b\" rel=\"nofollow\">http://twitter.com/?a&amp;b</a> &amp;",
+      "Escape non-entity text before and after a link while also escaping the link href and link text");
+
   // test urlClass
   same(twttr.txt.autoLink("http://twitter.com"), "<a href=\"http://twitter.com\" rel=\"nofollow\">http://twitter.com</a>", "AutoLink without urlClass");
   same(twttr.txt.autoLink("http://twitter.com", {urlClass: "testClass"}), "<a href=\"http://twitter.com\" class=\"testClass\" rel=\"nofollow\">http://twitter.com</a>", "autoLink with urlClass");

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -383,7 +383,7 @@ if (typeof twttr === "undefined" || twttr === null) {
                             'usernameUrlBlock':true, 'listUrlBlock':true, 'hashtagUrlBlock':true, 'linkUrlBlock':true,
                             'usernameIncludeSymbol':true, 'suppressLists':true, 'suppressNoFollow':true,
                             'suppressDataScreenName':true, 'urlEntities':true, 'symbolTag':true, 'textWithSymbolTag':true, 'urlTarget':true,
-                            'invisibleTagAttrs':true, 'linkAttributeBlock':true, 'linkTextBlock': true
+                            'invisibleTagAttrs':true, 'linkAttributeBlock':true, 'linkTextBlock': true, 'htmlEscapeNonEntities': true
                             };
   var BOOLEAN_ATTRIBUTES = {'disabled':true, 'readonly':true, 'multiple':true, 'checked':true};
 
@@ -614,9 +614,13 @@ if (typeof twttr === "undefined" || twttr === null) {
     // sort entities by start index
     entities.sort(function(a,b){ return a.indices[0] - b.indices[0]; });
 
+    var nonEntity = options.htmlEscapeNonEntities ? twttr.txt.htmlEscape : function(text) {
+      return text;
+    };
+
     for (var i = 0; i < entities.length; i++) {
       var entity = entities[i];
-      result += text.substring(beginIndex, entity.indices[0]);
+      result += nonEntity(text.substring(beginIndex, entity.indices[0]));
 
       if (entity.url) {
         result += twttr.txt.linkToUrl(entity, text, options);
@@ -629,7 +633,7 @@ if (typeof twttr === "undefined" || twttr === null) {
       }
       beginIndex = entity.indices[1];
     }
-    result += text.substring(beginIndex, text.length);
+    result += nonEntity(text.substring(beginIndex, text.length));
     return result;
   };
 


### PR DESCRIPTION
I need a way to convert raw tweet text that was just typed in (hasn't been html escaped at all) into safe html markup.  My problem with the current code is that it escapes text as it autolinks elements, but not the plain text between elements.

In other words, 
  "&lt; example.com/?a&b" 
gets converted into something like
  "&lt; &lt;a href="example.com/?a&amp;amp;b">example.com/?a&amp;amp;b"&lt;/a&gt;"
rather than
  "&amp;lt; &lt;a href="example.com/?a&amp;amp;b">example.com/?a&amp;amp;b"&lt;/a&gt;"

If I pre-escape the text myself, then the code that autolinks entities will add a redundant layer of escaping on the url.

I assume the current behavior is desirable in some circumstances, so I added this functionality as an option.  For example, tweets coming from twitter already have & < and > escaped.
