### PR TITLE
optionionally add `target="_blank"` attribute to links

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -151,6 +151,10 @@ test("twttr.txt.autolink", function() {
   ok(!autoLinkResult.match(/<a[^>]+username[^>]+dummy-hash-attr=\"test\"[^>]*>/), "linkAttributeBlock should not be applied to mention");
   ok(autoLinkResult.match(/<a[^>]+dummy-url-attr=\"http:\/\/twitter.com\/\"/), "linkAttributeBlock should be applied to URL");
 
+  // test targetBlank
+  ok(!twttr.txt.autoLink("#hash @mention").match(/target="_blank"/), "target=\"blank\" attribute should not be added to link");
+  ok(twttr.txt.autoLink("#hash @mention", { targetBlank: true }).match(/target="_blank"/), "target=\"blank\" attribute should be added to link");
+
   // test linkTextBlock
   autoLinkResult = twttr.txt.autoLink("#hash @mention", {
       linkTextBlock: function(entity, text) {

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -453,6 +453,9 @@ if (typeof twttr === "undefined" || twttr === null) {
     if (hashtag[0].match(twttr.txt.regexen.rtl_chars)){
       attrs["class"] += " rtl";
     }
+    if (options.targetBlank) {
+      attrs.target = '_blank';
+    }
 
     return twttr.txt.linkToTextWithSymbol(entity, hash, hashtag, attrs, options);
   };
@@ -463,6 +466,9 @@ if (typeof twttr === "undefined" || twttr === null) {
     attrs.href = options.cashtagUrlBase + cashtag;
     attrs.title = "$" + cashtag;
     attrs["class"] =  options.cashtagClass;
+    if (options.targetBlank) {
+      attrs.target = '_blank';
+    }
 
     return twttr.txt.linkToTextWithSymbol(entity, "$", cashtag, attrs, options);
   };
@@ -477,6 +483,9 @@ if (typeof twttr === "undefined" || twttr === null) {
     attrs.href = isList ? options.listUrlBase + user + slashListname : options.usernameUrlBase + user;
     if (!isList && !options.suppressDataScreenName) {
       attrs['data-screen-name'] = user;
+    }
+    if (options.targetBlank) {
+      attrs.target = '_blank';
     }
 
     return twttr.txt.linkToTextWithSymbol(entity, at, isList ? user + slashListname : user, attrs, options);
@@ -497,6 +506,10 @@ if (typeof twttr === "undefined" || twttr === null) {
 
     var attrs = clone(options.htmlAttrs || {});
     attrs.href = url;
+
+    if (options.targetBlank) {
+      attrs.target = '_blank';
+    }
 
     // set class only if urlClass is specified.
     if (options.urlClass) {


### PR DESCRIPTION
For opening links in new tabs. Made the option name `targetBlank` but could easily be changed.
