### PR TITLE
Fix for upcoming t.co length changes

### DIFF
--- a/twitter-text.js
+++ b/twitter-text.js
@@ -1158,8 +1158,8 @@ if (typeof twttr === "undefined" || twttr === null) {
   twttr.txt.getTweetLength = function(text, options) {
     if (!options) {
       options = {
-          short_url_length: 20,
-          short_url_length_https: 21
+          short_url_length: 22,
+          short_url_length_https: 23
       };
     }
     var textLength = text.length;


### PR DESCRIPTION
Twitter is going to be extending the maximum length of t.co wrapped links from 20 to 22 characters for non-https URLs, and 21 to 23 characters for https URLs.

This pull request updates the short_url_length and short_url_length_https options to match the coming t.co update mentioned here: https://dev.twitter.com/blog/upcoming-tco-changes
