### PR TITLE
@ symbols also breaking when found in the last section of the path of the URL

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -58,6 +58,11 @@ test("twttr.txt.extract", function() {
   twttr.txt.modifyIndicesFromUnicodeToUTF16(text, extracted);
   same(extracted, [{url:"http://twitter.com", indices:[3, 21]}, {url:"http://test.com", indices:[25, 40]}], "URL w/ Supplementary character, UTF-16 indices");
 
+  // handle when the url path ends with @ symbols
+  text = "http://twitter.com/path/more@twitter \uD801\uDC00 http://test.com"
+  extracted = twttr.txt.extractUrlsWithIndices(text);
+  same(extracted, [ { "url": "http://twitter.com/path/more@twitter", "indices": [ 0, 36 ] }, { "url": "http://test.com", "indices": [ 40, 55 ] } ], "URL w/ Supplementary character, @ symbols in valid url path");
+
   var testCases = [
     {text:"abc", indices:[[0,3]], unicode_indices:[[0,3]]},
     {text:"\uD83D\uDE02abc", indices:[[2,5]], unicode_indices:[[1,4]]},

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -243,7 +243,7 @@ if (typeof twttr === "undefined" || twttr === null) {
 
   twttr.txt.regexen.validPortNumber = regexSupplant(/[0-9]+/);
 
-  twttr.txt.regexen.validGeneralUrlPathChars = regexSupplant(/[a-z0-9!\*';:=\+,\.\$\/%#\[\]\-_~|&#{latinAccentChars}]/i);
+  twttr.txt.regexen.validGeneralUrlPathChars = regexSupplant(/[a-z0-9!\*';:=\+,\.\$\/%#\[\]\-_~|&@#{latinAccentChars}]/i);
   // Allow URL paths to contain balanced parens
   //  1. Used in Wikipedia URLs like /Primer_(film)
   //  2. Used in IIS sessions like /S(dfd346)/


### PR DESCRIPTION
Previously, a URL such as:

> http://twitter.com/path/more@twitter

 is extracted to read:

> http://twitter.com/path/more

but a similar path:

> http://twitter.com/path/more@twitter/

is not dropped in the same approach.

This fix adds the @ symbol as part of a general url path character, as it is allowed in code.
Here is a real world URL that brought this bug to light.

> http://www.stjohns.edu/alumni/pr_alu_130107b.news_item@digest.stjohns.edu%2falumni%2fpr_alu_130107b.xml?context_date=1/9/2013

A test was also added to check for this.
