### PR TITLE
When autolinking urls, make sure there is always a protocol on the href

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -174,6 +174,10 @@ test("twttr.txt.autolink", function() {
   ok(autoLinkResult.match(/<a[^>]+>pre_<s>#<\/s><b>hash<\/b>_post<\/a>/), "linkTextBlock should modify a hashtag link text");
   ok(autoLinkResult.match(/<a[^>]+>pre_<s>@<\/s><b>mention<\/b>_post<\/a>/), "linkTextBlock should modify a username link text");
 
+  // extractUrlsWithoutProtocol (the default mode of extractEntitiesWithIndices)
+  same(twttr.txt.autoLinkEntities("twitter.com", twttr.txt.extractEntitiesWithIndices("twitter.com")),
+      "<a href=\"http://twitter.com\" rel=\"nofollow\">twitter.com</a>", "AutoLink with extractUrlsWithoutProtocol");
+
   // url entities
   autoLinkResult = twttr.txt.autoLink("http://t.co/0JG5Mcq", {
     invisibleTagAttrs: "style='font-size:0'",

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -271,6 +271,8 @@
   , 'gi');
 
   twttr.txt.regexen.validTcoUrl = /^https?:\/\/t\.co\/[a-z0-9]+/i;
+  twttr.txt.regexen.urlHasProtocol = /^https?:\/\//i;
+  twttr.txt.regexen.urlHasHttps = /^https:\/\//i;
 
   // cashtag related regex
   twttr.txt.regexen.cashtag = /[a-z]{1,6}(?:[._][a-z]{1,2})?/i;
@@ -501,6 +503,10 @@
     }
 
     var attrs = clone(options.htmlAttrs || {});
+
+    if (!url.match(twttr.txt.regexen.urlHasProtocol)) {
+      url = "http://" + url;
+    }
     attrs.href = url;
 
     if (options.targetBlank) {
@@ -1175,9 +1181,9 @@
     	// Subtract the length of the original URL
       textLength += urlsWithIndices[i].indices[0] - urlsWithIndices[i].indices[1];
 
-      // Add 21 characters for URL starting with https://
-      // Otherwise add 20 characters
-      if (urlsWithIndices[i].url.toLowerCase().match(/^https:\/\//)) {
+      // Add 23 characters for URL starting with https://
+      // Otherwise add 22 characters
+      if (urlsWithIndices[i].url.toLowerCase().match(twttr.txt.regexen.ursHasHttps)) {
          textLength += options.short_url_length_https;
       } else {
         textLength += options.short_url_length;

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -1183,7 +1183,7 @@
 
       // Add 23 characters for URL starting with https://
       // Otherwise add 22 characters
-      if (urlsWithIndices[i].url.toLowerCase().match(twttr.txt.regexen.ursHasHttps)) {
+      if (urlsWithIndices[i].url.toLowerCase().match(twttr.txt.regexen.urlHasHttps)) {
          textLength += options.short_url_length_https;
       } else {
         textLength += options.short_url_length;


### PR DESCRIPTION
We had to fix this autolinking anomaly after the fact in the twitter.com repo, it might be nice to fix it here instead.  For example, <a href="example.com">example.com</a> is broken without a protocol.

Also, someone may wish to make extractUrlsWithoutProtocol default to true when calling twttr.txt.autoLink soon.  Or at least allow the options to override it. Or both. Considering twitter's backend has been doing autolinking without protocol for several months now, it doesn't' make sense for this to be hard-coded off. 
