### PR TITLE
fix autolink error on concatenate symbols entities

### DIFF
--- a/twitter-text.js
+++ b/twitter-text.js
@@ -696,7 +696,7 @@
     }
     
     if (json.symbols) {
-      for (var i = 0; i < json.hashtags.length; i++) {
+      for (var i = 0; i < json.symbols.length; i++) {
         // this is a $CASH tag
         json.symbols[i].cashtag = json.symbols[i].text;
       }


### PR DESCRIPTION
This is just a small fix on the autolinkWithJSON function where there was a typo in a for loop.
