### PR TITLE
Use a case insensitive regex when ignoring invalid short domains

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -177,6 +177,8 @@ test("twttr.txt.autolink", function() {
   // extractUrlsWithoutProtocol (the default mode of extractEntitiesWithIndices)
   deepEqual(twttr.txt.autoLinkEntities("twitter.com", twttr.txt.extractEntitiesWithIndices("twitter.com")),
       "<a href=\"http://twitter.com\" rel=\"nofollow\">twitter.com</a>", "AutoLink with extractUrlsWithoutProtocol");
+  deepEqual(twttr.txt.autoLinkEntities("twitter.com", twttr.txt.extractEntitiesWithIndices("MLB.TV")),
+      "MLB.TV", "Don't AutoLink withoutProtocol just because domain is uppercase");
 
   // url entities
   autoLinkResult = twttr.txt.autoLink("http://t.co/0JG5Mcq", {

--- a/test/tests.js
+++ b/test/tests.js
@@ -177,7 +177,7 @@ test("twttr.txt.autolink", function() {
   // extractUrlsWithoutProtocol (the default mode of extractEntitiesWithIndices)
   deepEqual(twttr.txt.autoLinkEntities("twitter.com", twttr.txt.extractEntitiesWithIndices("twitter.com")),
       "<a href=\"http://twitter.com\" rel=\"nofollow\">twitter.com</a>", "AutoLink with extractUrlsWithoutProtocol");
-  deepEqual(twttr.txt.autoLinkEntities("twitter.com", twttr.txt.extractEntitiesWithIndices("MLB.TV")),
+  deepEqual(twttr.txt.autoLinkEntities("MLB.TV", twttr.txt.extractEntitiesWithIndices("MLB.TV")),
       "MLB.TV", "Don't AutoLink withoutProtocol just because domain is uppercase");
 
   // url entities

--- a/twitter-text.js
+++ b/twitter-text.js
@@ -257,7 +257,7 @@
   twttr.txt.regexen.validPunycode = regexSupplant(/(?:xn--[0-9a-z]+)/);
   twttr.txt.regexen.validDomain = regexSupplant(/(?:#{validSubdomain}*#{validDomainName}(?:#{validGTLD}|#{validCCTLD}|#{validPunycode}))/);
   twttr.txt.regexen.validAsciiDomain = regexSupplant(/(?:(?:[\-a-z0-9#{latinAccentChars}]+)\.)+(?:#{validGTLD}|#{validCCTLD}|#{validPunycode})/gi);
-  twttr.txt.regexen.invalidShortDomain = regexSupplant(/^#{validDomainName}#{validCCTLD}$/);
+  twttr.txt.regexen.invalidShortDomain = regexSupplant(/^#{validDomainName}#{validCCTLD}$/i);
 
   twttr.txt.regexen.validPortNumber = regexSupplant(/[0-9]+/);
 


### PR DESCRIPTION
This change is needed so things like MLB.TV don't get linkified (twitter.com will NOT linkify them on the server)

I can't figure out how to run the unit tests, can someone who is maintaining this very that and bump up the version for me?
- Tom Wuttke
