### PR TITLE
Failing test for autoLinkWithJSON processes photo media urls correctly

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -307,3 +307,69 @@ test("twttr.txt.extractUrls", function() {
   equal(twttr.txt.extractUrls(message_with_hyphenated_url)[0], "hyphenated-url.com", "Should extract full url with hyphen.");
   equal(twttr.txt.extractUrls(message_with_www_hyphenated_url)[0], "www.123-hyphenated-url.com", "Should extract full url with hyphen.");
 });
+
+
+test("autoLinkWithJSON processes photo media urls correctly", function(){
+  // This is based on tweet 461969656568246272
+  var tweet = "@BalloonAF lmao this is all I need to roast you😂 look like a damn chipmunk gtfo my mentions😂 http://t.co/YKvfV1z3Z8";
+  var entities = {
+    "hashtags": [],
+    "symbols": [],
+    "urls": [],
+    "user_mentions": [
+      {
+        "screen_name": "BalloonAF",
+        "name": "mew.",
+        "id": 1097391858,
+        "id_str": "1097391858",
+        "indices": [
+          0,
+          10
+        ],
+        "screenName": "BalloonAF"
+      }
+    ],
+    "media": [
+      {
+        "id": 461969629477220350,
+        "id_str": "461969629477220352",
+        "indices": [
+          97,
+          119
+        ],
+        "media_url": "http://pbs.twimg.com/media/Bmk-7i4CMAALr8X.jpg",
+        "media_url_https": "https://pbs.twimg.com/media/Bmk-7i4CMAALr8X.jpg",
+        "url": "http://t.co/YKvfV1z3Z8",
+        "display_url": "pic.twitter.com/YKvfV1z3Z8",
+        "expanded_url": "http://twitter.com/PhD_KoleKat/status/461969656568246272/photo/1",
+        "type": "photo",
+        "sizes": {
+          "thumb": {
+            "w": 150,
+            "h": 150,
+            "resize": "crop"
+          },
+          "small": {
+            "w": 340,
+            "h": 453,
+            "resize": "fit"
+          },
+          "medium": {
+            "w": 480,
+            "h": 640,
+            "resize": "fit"
+          },
+          "large": {
+            "w": 480,
+            "h": 640,
+            "resize": "fit"
+          }
+        }
+      }
+    ]
+  };
+
+  var expectedResult = "<a class=\"tweet-url username\" href=\"https://twitter.com/BalloonAF\" data-screen-name=\"BalloonAF\" rel=\"nofollow\">@BalloonAF</a> lmao this is all I need to roast you😂 look like a damn chipmunk gtfo my mentions😂 <a href=\"http://t.co/YKvfV1z3Z8\" title=\"http://twitter.com/PhD_KoleKat/status/461969656568246272/photo/1\" rel=\"nofollow\">pic.twitter.com/YKvfV1z3Z8</a>";
+
+  equal(twttr.txt.autoLinkWithJSON(tweet, entities), expectedResult);
+});


### PR DESCRIPTION
Photo media urls have extra characters inserted before them.  I'm not sure if it requires emoji in the tweet to make it break - perhaps.

![image](https://cloud.githubusercontent.com/assets/19700/2857738/04c5e842-d17c-11e3-8d35-38d3f8531c2d.png)
