### PR TITLE
Redirect to playground instead of embedding

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,1 @@
-<iframe width="100%" height="100%" src="http://requirebin.com/embed?gist=5970448" frameborder="0" allowfullscreen></iframe>
+<meta http-equiv="refresh" content="0;url=http://requirebin.com/embed?gist=5970448">


### PR DESCRIPTION
This avoids a mixed content failure for users of HTTPS Everywhere.
