### PR TITLE
Add AMD support

### DIFF
--- a/twitter-text.js
+++ b/twitter-text.js
@@ -1371,6 +1371,10 @@
     module.exports = twttr.txt;
   }
 
+  if (typeof define == 'function' && define.amd) {
+    define([], twttr.txt);
+  }
+
   if (typeof window != 'undefined') {
     if (window.twttr) {
       for (var prop in twttr) {


### PR DESCRIPTION
This is a very small change that would make it easier for those of us using requirejs in our build process. Currently, we have to either create a dummy module that returns the global `twttr.txt` object, or do lots of ugly configuration to get it to play nice.
